### PR TITLE
Epic: build decisions from oq

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A CLI tool to automatically process Slack discussions and generate specification
 - `python agent.py oq_transform` - Convert decided OQs to PUs (batch)
 - `python agent.py oq_delete <oq_id>` - Delete an OQ and mark its artifact IRRELEVANT
 - `python agent.py oq_delete <id1> <id2> ...` - Batch delete OQs
+- `python agent.py publish_oq <id1> <id2> ...` - Publish OQs to Slack (republish only if modified)
 - `python agent.py approve_pu <pu_id>` - Approve a proposed update
 - `python agent.py change_status <id1> <id2> ... <status>` - Change status for one or more artifacts
 - `python agent.py change_status --status <status> <id1> <id2> ...` - Alternative syntax
@@ -47,6 +48,18 @@ A CLI tool to automatically process Slack discussions and generate specification
 - `python agent.py set_last_ts --days <n>` - Set last_ts to N days back (asks if missing)
 - `python agent.py reset_data` - Clear all stored JSON data (asks for confirmation)
 - `python agent.py reset_data --yes` - Clear data without prompt
+
+### UI (Desktop)
+
+1. Install UI dependency:
+   ```bash
+   pip install pyside6
+   ```
+
+2. Launch the UI from the project root:
+   ```bash
+   python ui.py
+   ```
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ A CLI tool to automatically process Slack discussions and generate specification
 - `python agent.py change_status <id1> <id2> ... <status>` - Change status for one or more artifacts
 - `python agent.py change_status --status <status> <id1> <id2> ...` - Alternative syntax
 - `python agent.py init_sync` - Initialize sync timestamp (skip history)
+- `python agent.py reset_data` - Clear all stored JSON data (asks for confirmation)
+- `python agent.py reset_data --yes` - Clear data without prompt
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ A CLI tool to automatically process Slack discussions and generate specification
 - `python agent.py oq_decide <oq_id>` - Add decision + rationale to an OQ
 - `python agent.py oq_modify <oq_id>` - Modify fields of an OQ (question/context/decision/rationale)
 - `python agent.py oq_transform` - Convert decided OQs to PUs (batch)
+- `python agent.py oq_delete <oq_id>` - Delete an OQ and mark its artifact IRRELEVANT
 - `python agent.py approve_pu <pu_id>` - Approve a proposed update
 - `python agent.py change_status <id1> <id2> ... <status>` - Change status for one or more artifacts
 - `python agent.py change_status --status <status> <id1> <id2> ...` - Alternative syntax
 - `python agent.py init_sync` - Initialize sync timestamp (skip history)
+- `python agent.py set_last_ts --days <n>` - Set last_ts to N days back (asks if missing)
 - `python agent.py reset_data` - Clear all stored JSON data (asks for confirmation)
 - `python agent.py reset_data --yes` - Clear data without prompt
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A CLI tool to automatically process Slack discussions and generate specification
 - `python agent.py oq_modify <oq_id>` - Modify fields of an OQ (question/context/decision/rationale)
 - `python agent.py oq_transform` - Convert decided OQs to PUs (batch)
 - `python agent.py oq_delete <oq_id>` - Delete an OQ and mark its artifact IRRELEVANT
+- `python agent.py oq_delete <id1> <id2> ...` - Batch delete OQs
 - `python agent.py approve_pu <pu_id>` - Approve a proposed update
 - `python agent.py change_status <id1> <id2> ... <status>` - Change status for one or more artifacts
 - `python agent.py change_status --status <status> <id1> <id2> ...` - Alternative syntax

--- a/src/adapters/data_reset_json.py
+++ b/src/adapters/data_reset_json.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from src.adapters.storage_utils import save_json
+
+
+class JsonDataResetAdapter:
+    def reset_all(self) -> None:
+        save_json("conversations.json", {"conversations": []})
+        save_json("artifacts.json", {"artifacts": []})
+        save_json("open_questions.json", {"questions": []})
+        save_json("proposed_updates.json", {"updates": []})
+        save_json("slack_threads.json", {"threads": []})

--- a/src/adapters/openai.py
+++ b/src/adapters/openai.py
@@ -21,6 +21,16 @@ def _load_prompt(name: str, **kwargs) -> str:
     return template
 
 
+def _parse_json(text: str) -> dict | None:
+    import json
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        print("Error parsing LLM response.")
+        return None
+
+
 class OpenAILLMClassifier:
     def __init__(self) -> None:
         api_key = os.getenv("OPENAI_API_KEY")
@@ -36,16 +46,33 @@ class OpenAILLMClassifier:
                 messages=[{"role": "user", "content": prompt}],
                 response_format={"type": "json_object"},
             )
-            return response.choices[0].message.content and self._parse_json(response.choices[0].message.content)
+            return response.choices[0].message.content and _parse_json(response.choices[0].message.content)
         except Exception as e:
             print(f"Error calling OpenAI API: {e}")
             return None
 
-    def _parse_json(self, text: str) -> dict | None:
-        import json
+
+class OpenAILLMDecision:
+    def __init__(self) -> None:
+        api_key = os.getenv("OPENAI_API_KEY")
+        self.client = OpenAI(api_key=api_key)
+
+    def decide(self, question: str, context: str, thread_text: str) -> dict | None:
+        prompt = _load_prompt(
+            "decision_from_thread",
+            question=question,
+            context=context,
+            thread=thread_text,
+        )
+        model = os.getenv("OPENAI_DECISION_MODEL", os.getenv("OPENAI_MODEL", "gpt-4o"))
 
         try:
-            return json.loads(text)
-        except json.JSONDecodeError:
-            print("Error parsing LLM response.")
+            response = self.client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                response_format={"type": "json_object"},
+            )
+            return response.choices[0].message.content and _parse_json(response.choices[0].message.content)
+        except Exception as e:
+            print(f"Error calling OpenAI API: {e}")
             return None

--- a/src/adapters/repo_json.py
+++ b/src/adapters/repo_json.py
@@ -45,6 +45,9 @@ class JsonArtifactRepository:
             rephrasing=item.get("rephrasing", ""),
             rationale=item.get("rationale", ""),
             summary_of_context=item.get("summary_of_context", ""),
+            source_channel_id=item.get("source_channel_id"),
+            source_thread_ts=item.get("source_thread_ts", item.get("conversation_id")),
+            source_thread_url=item.get("source_thread_url"),
         )
 
     def _to_dict(self, artifact: Artifact) -> dict:
@@ -56,6 +59,9 @@ class JsonArtifactRepository:
             "rephrasing": artifact.rephrasing,
             "rationale": artifact.rationale,
             "summary_of_context": artifact.summary_of_context,
+            "source_channel_id": artifact.source_channel_id,
+            "source_thread_ts": artifact.source_thread_ts,
+            "source_thread_url": artifact.source_thread_url,
         }
 
 
@@ -109,6 +115,9 @@ class JsonOpenQuestionRepository:
             published_message_ts=None,
             published_channel_id=None,
             last_modified_at=None,
+            source_channel_id=artifact.source_channel_id,
+            source_thread_ts=artifact.source_thread_ts or artifact.conversation_id,
+            source_thread_url=artifact.source_thread_url,
         )
 
         data = load_json("open_questions.json")
@@ -128,6 +137,9 @@ class JsonOpenQuestionRepository:
             "slack_ts": oq.slack_ts,
             "decision": oq.decision,
             "decision_rationale": oq.decision_rationale,
+            "source_channel_id": oq.source_channel_id,
+            "source_thread_ts": oq.source_thread_ts,
+            "source_thread_url": oq.source_thread_url,
             "published_at": oq.published_at,
             "published_message_ts": oq.published_message_ts,
             "published_channel_id": oq.published_channel_id,
@@ -144,6 +156,9 @@ class JsonOpenQuestionRepository:
             slack_ts=item.get("slack_ts"),
             decision=item.get("decision"),
             decision_rationale=item.get("decision_rationale"),
+            source_channel_id=item.get("source_channel_id"),
+            source_thread_ts=item.get("source_thread_ts"),
+            source_thread_url=item.get("source_thread_url"),
             published_at=item.get("published_at"),
             published_message_ts=item.get("published_message_ts"),
             published_channel_id=item.get("published_channel_id"),
@@ -197,6 +212,9 @@ class JsonProposedUpdateRepository:
             decision="",
             rationale=artifact.rationale,
             status="DRAFT",
+            source_channel_id=artifact.source_channel_id,
+            source_thread_ts=artifact.source_thread_ts or artifact.conversation_id,
+            source_thread_url=artifact.source_thread_url,
         )
 
         data = load_json("proposed_updates.json")
@@ -216,6 +234,9 @@ class JsonProposedUpdateRepository:
             "decision": pu.decision,
             "rationale": pu.rationale,
             "status": pu.status,
+            "source_channel_id": pu.source_channel_id,
+            "source_thread_ts": pu.source_thread_ts,
+            "source_thread_url": pu.source_thread_url,
         }
 
     def _from_dict(self, item: dict) -> ProposedUpdate:
@@ -228,6 +249,9 @@ class JsonProposedUpdateRepository:
             decision=item.get("decision", ""),
             rationale=item.get("rationale", ""),
             status=item.get("status", "DRAFT"),
+            source_channel_id=item.get("source_channel_id"),
+            source_thread_ts=item.get("source_thread_ts"),
+            source_thread_url=item.get("source_thread_url"),
         )
 
 

--- a/src/adapters/repo_json.py
+++ b/src/adapters/repo_json.py
@@ -105,6 +105,10 @@ class JsonOpenQuestionRepository:
             slack_ts=None,
             decision=None,
             decision_rationale=None,
+            published_at=None,
+            published_message_ts=None,
+            published_channel_id=None,
+            last_modified_at=None,
         )
 
         data = load_json("open_questions.json")
@@ -124,6 +128,10 @@ class JsonOpenQuestionRepository:
             "slack_ts": oq.slack_ts,
             "decision": oq.decision,
             "decision_rationale": oq.decision_rationale,
+            "published_at": oq.published_at,
+            "published_message_ts": oq.published_message_ts,
+            "published_channel_id": oq.published_channel_id,
+            "last_modified_at": oq.last_modified_at,
         }
 
     def _from_dict(self, item: dict) -> OpenQuestion:
@@ -136,6 +144,10 @@ class JsonOpenQuestionRepository:
             slack_ts=item.get("slack_ts"),
             decision=item.get("decision"),
             decision_rationale=item.get("decision_rationale"),
+            published_at=item.get("published_at"),
+            published_message_ts=item.get("published_message_ts"),
+            published_channel_id=item.get("published_channel_id"),
+            last_modified_at=item.get("last_modified_at"),
         )
 
 

--- a/src/adapters/repo_json.py
+++ b/src/adapters/repo_json.py
@@ -88,6 +88,13 @@ class JsonOpenQuestionRepository:
         data["questions"] = questions
         save_json("open_questions.json", data)
 
+    def delete_by_id(self, oq_id: str) -> None:
+        data = load_json("open_questions.json")
+        questions = data.get("questions", [])
+        questions = [item for item in questions if item.get("id") != oq_id]
+        data["questions"] = questions
+        save_json("open_questions.json", data)
+
     def create_from_artifact(self, artifact: Artifact) -> OpenQuestion:
         oq = OpenQuestion(
             id=f"oq_{uuid.uuid4().hex[:8]}",

--- a/src/adapters/slack_publish.py
+++ b/src/adapters/slack_publish.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+load_dotenv(override=True)
+
+
+class SlackSDKPublishAdapter:
+    def __init__(self) -> None:
+        token = os.getenv("SLACK_BOT_TOKEN")
+        self.client = WebClient(token=token)
+
+    def post_message(self, channel_id: str, text: str) -> str:
+        try:
+            result = self.client.chat_postMessage(channel=channel_id, text=text)
+            return result.get("ts")
+        except SlackApiError as e:
+            raise RuntimeError(f"Error posting message: {e.response['error']}")
+
+    def update_message(self, channel_id: str, message_ts: str, text: str) -> str:
+        try:
+            result = self.client.chat_update(channel=channel_id, ts=message_ts, text=text)
+            return result.get("ts")
+        except SlackApiError as e:
+            raise RuntimeError(f"Error updating message: {e.response['error']}")

--- a/src/adapters/slack_reader.py
+++ b/src/adapters/slack_reader.py
@@ -8,6 +8,16 @@ load_dotenv(override=True)
 
 client = WebClient(token=os.getenv("SLACK_BOT_TOKEN"))
 
+def _get_thread_permalink(channel_id, thread_ts):
+    if not channel_id or not thread_ts:
+        return None
+    try:
+        result = client.chat_getPermalink(channel=channel_id, message_ts=thread_ts)
+        return result.get("permalink")
+    except SlackApiError as e:
+        print(f"Error fetching permalink for {thread_ts}: {e.response['error']}")
+        return None
+
 def fetch_slack_threads(channel_id):
     print(f"Fetching threads for channel: {channel_id}...")
     
@@ -35,6 +45,8 @@ def fetch_slack_threads(channel_id):
                     )
                     all_threads.append({
                         "ts": ts,
+                        "channel_id": channel_id,
+                        "thread_url": _get_thread_permalink(channel_id, ts),
                         "messages": replies.get("messages", [])
                     })
                 except SlackApiError as e:
@@ -43,6 +55,8 @@ def fetch_slack_threads(channel_id):
                 # Individual message treated as a single-message thread
                 all_threads.append({
                     "ts": ts,
+                    "channel_id": channel_id,
+                    "thread_url": _get_thread_permalink(channel_id, ts),
                     "messages": [msg]
                 })
 
@@ -59,6 +73,20 @@ def fetch_slack_threads(channel_id):
         print(f"Error fetching history: {e.response['error']}")
     
     return all_threads
+
+def fetch_slack_thread(channel_id, thread_ts):
+    print(f"Fetching thread replies for channel: {channel_id}, thread: {thread_ts}...")
+    try:
+        replies = client.conversations_replies(channel=channel_id, ts=thread_ts)
+        return {
+            "ts": thread_ts,
+            "channel_id": channel_id,
+            "thread_url": _get_thread_permalink(channel_id, thread_ts),
+            "messages": replies.get("messages", []),
+        }
+    except SlackApiError as e:
+        print(f"Error fetching replies for {thread_ts}: {e.response['error']}")
+        return None
 
 def normalize_thread(thread):
     conv_text = ""

--- a/src/adapters/slack_sdk.py
+++ b/src/adapters/slack_sdk.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from src.adapters.slack_reader import fetch_slack_threads
+from src.adapters.slack_reader import fetch_slack_thread, fetch_slack_threads
 
 
 class SlackSDKThreadsAdapter:
     def fetch_threads(self, channel_id: str) -> list[dict]:
         return fetch_slack_threads(channel_id)
+
+    def fetch_thread(self, channel_id: str, thread_ts: str) -> dict | None:
+        return fetch_slack_thread(channel_id, thread_ts)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -22,6 +22,7 @@ from src.cli.wiring import (
     build_reset_data_use_case,
     build_set_last_ts_use_case,
     build_delete_oq_use_case,
+    build_delete_oq_batch_use_case,
 )
 
 class SpecsUpdatesAgent:
@@ -56,8 +57,8 @@ class SpecsUpdatesAgent:
         subparsers.add_parser("oq_transform", help="Transform decided OQs into PUs")
 
         # Command: oq_delete
-        oq_delete_parser = subparsers.add_parser("oq_delete", help="Delete an OQ and mark its artifact IRRELEVANT")
-        oq_delete_parser.add_argument("oq_id", help="OQ ID")
+        oq_delete_parser = subparsers.add_parser("oq_delete", help="Delete one or more OQs and mark artifacts IRRELEVANT")
+        oq_delete_parser.add_argument("oq_ids", nargs="+", help="OQ IDs")
         oq_delete_parser.add_argument("--yes", action="store_true", help="Confirm delete without prompt")
 
         # Command: approve_pu
@@ -179,19 +180,28 @@ class SpecsUpdatesAgent:
         print(f"Decision saved for OQ {args.oq_id}.")
 
     def cmd_oq_delete(self, args):
+        oq_ids = list(args.oq_ids)
+        if not oq_ids:
+            print("No OQ IDs provided.")
+            return
+
         if not args.yes:
-            confirm = input(f"Delete OQ {args.oq_id} and mark its artifact IRRELEVANT? (y/n): ").strip().lower()
+            plural = "s" if len(oq_ids) > 1 else ""
+            confirm = input(
+                f"Delete {len(oq_ids)} OQ{plural} and mark artifact(s) IRRELEVANT? (y/n): "
+            ).strip().lower()
             if confirm not in {"y", "yes"}:
                 print("Delete cancelled.")
                 return
 
-        use_case = build_delete_oq_use_case()
-        result = use_case.execute(args.oq_id)
-        if not result.deleted:
-            print(f"OQ {args.oq_id} not found.")
-            return
+        use_case = build_delete_oq_batch_use_case()
+        result = use_case.execute(oq_ids)
 
-        print(f"OQ {args.oq_id} deleted.")
+        if result.missing_ids:
+            print(f"Not found: {', '.join(result.missing_ids)}")
+
+        if result.deleted_ids:
+            print(f"Deleted: {', '.join(result.deleted_ids)}")
 
     def cmd_approve_pu(self, args):
         print(f"Approving PU {args.pu_id}...")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -11,6 +11,7 @@ from src.cli.wiring import (
     build_transform_artifacts_use_case,
     build_transform_oq_use_case,
     build_add_decision_use_case,
+    build_decision_from_thread_use_case,
     build_modify_oq_use_case,
     build_approve_pu_use_case,
     build_change_artifact_status_use_case,
@@ -53,6 +54,12 @@ class SpecsUpdatesAgent:
         # Command: oq_decide
         oq_decide_parser = subparsers.add_parser("oq_decide", help="Add a decision to an Open Question")
         oq_decide_parser.add_argument("oq_id", help="OQ ID")
+
+        # Command: oq_decide_thread
+        oq_decide_thread_parser = subparsers.add_parser(
+            "oq_decide_thread", help="Build decision from Slack thread replies"
+        )
+        oq_decide_thread_parser.add_argument("oq_id", help="OQ ID")
 
         # Command: oq_transform
         subparsers.add_parser("oq_transform", help="Transform decided OQs into PUs")
@@ -184,6 +191,33 @@ class SpecsUpdatesAgent:
             return
 
         print(f"Decision saved for OQ {args.oq_id}.")
+
+    def cmd_oq_decide_thread(self, args):
+        print(f"Building decision from Slack thread for OQ {args.oq_id}...")
+        use_case = build_decision_from_thread_use_case()
+        result = use_case.execute(args.oq_id)
+
+        if not result.updated:
+            reason = result.reason or "unknown_error"
+            if reason == "missing_oq":
+                print(f"OQ {args.oq_id} not found.")
+            elif reason == "not_published":
+                print("OQ is not published to Slack yet.")
+            elif reason == "thread_missing":
+                print("Slack thread not found or empty.")
+            elif reason == "no_tech_messages":
+                print("No tech team replies found in the thread.")
+            elif reason == "llm_failed":
+                print("LLM failed to generate a decision.")
+            elif reason == "empty_decision":
+                print("LLM returned an empty decision or rationale.")
+            else:
+                print(f"Failed to build decision: {reason}")
+            return
+
+        print(f"Decision saved for OQ {args.oq_id}.")
+        if result.decision:
+            print(f"Decision: {result.decision}")
 
     def cmd_oq_delete(self, args):
         oq_ids = list(args.oq_ids)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -23,6 +23,7 @@ from src.cli.wiring import (
     build_set_last_ts_use_case,
     build_delete_oq_use_case,
     build_delete_oq_batch_use_case,
+    build_publish_oqs_use_case,
 )
 
 class SpecsUpdatesAgent:
@@ -60,6 +61,11 @@ class SpecsUpdatesAgent:
         oq_delete_parser = subparsers.add_parser("oq_delete", help="Delete one or more OQs and mark artifacts IRRELEVANT")
         oq_delete_parser.add_argument("oq_ids", nargs="+", help="OQ IDs")
         oq_delete_parser.add_argument("--yes", action="store_true", help="Confirm delete without prompt")
+
+        # Command: publish_oq
+        publish_parser = subparsers.add_parser("publish_oq", help="Publish one or more OQs to Slack")
+        publish_parser.add_argument("oq_ids", nargs="+", help="OQ IDs")
+        publish_parser.add_argument("--channel", help="Slack channel ID (optional, uses .env or --channel)")
 
         # Command: approve_pu
         pu_app_parser = subparsers.add_parser("approve_pu", help="Approve a Proposed Update")
@@ -202,6 +208,27 @@ class SpecsUpdatesAgent:
 
         if result.deleted_ids:
             print(f"Deleted: {', '.join(result.deleted_ids)}")
+
+    def cmd_publish_oq(self, args):
+        channel_id = args.channel or os.getenv("SLACK_CHANNEL_ID", "general")
+        oq_ids = list(args.oq_ids)
+        if not oq_ids:
+            print("No OQ IDs provided.")
+            return
+
+        use_case = build_publish_oqs_use_case()
+        result = use_case.execute(oq_ids, channel_id)
+
+        if result.missing_ids:
+            print(f"Not found: {', '.join(result.missing_ids)}")
+        if result.failed_ids:
+            print(f"Failed: {', '.join(result.failed_ids)}")
+        if result.skipped_ids:
+            print(f"Skipped (not modified): {', '.join(result.skipped_ids)}")
+        if result.updated_ids:
+            print(f"Updated: {', '.join(result.updated_ids)}")
+        if result.published_ids:
+            print(f"Published: {', '.join(result.published_ids)}")
 
     def cmd_approve_pu(self, args):
         print(f"Approving PU {args.pu_id}...")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -19,6 +19,7 @@ from src.cli.wiring import (
     build_list_open_questions_use_case,
     build_list_proposed_updates_use_case,
     build_init_sync_use_case,
+    build_reset_data_use_case,
 )
 
 class SpecsUpdatesAgent:
@@ -59,6 +60,10 @@ class SpecsUpdatesAgent:
         # Command: init_sync
         init_parser = subparsers.add_parser("init_sync", help="Initialize the sync timestamp to current time to skip history")
         init_parser.add_argument("--channel", help="Specific channel ID to initialize (optional, uses .env or --channel)")
+
+        # Command: reset_data
+        reset_parser = subparsers.add_parser("reset_data", help="Reset stored JSON data")
+        reset_parser.add_argument("--yes", action="store_true", help="Confirm reset without prompt")
 
         # Command: art_list
         subparsers.add_parser("art_list", help="List all artifacts")
@@ -265,6 +270,18 @@ class SpecsUpdatesAgent:
             if len(rephrasing) > 60:
                 rephrasing = rephrasing[:57] + "..."
             print(f"{pu.id:<25} {pu.status:<15} {rephrasing}")
+
+    def cmd_reset_data(self, args):
+        if not args.yes:
+            confirm = input("This will clear all data JSON files. Continue? (y/n): ").strip().lower()
+            if confirm not in {"y", "yes"}:
+                print("Reset cancelled.")
+                return
+
+        use_case = build_reset_data_use_case()
+        result = use_case.execute()
+        if result.success:
+            print("Data reset completed.")
 
 def main():
     agent = SpecsUpdatesAgent()

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -20,6 +20,8 @@ from src.cli.wiring import (
     build_list_proposed_updates_use_case,
     build_init_sync_use_case,
     build_reset_data_use_case,
+    build_set_last_ts_use_case,
+    build_delete_oq_use_case,
 )
 
 class SpecsUpdatesAgent:
@@ -53,6 +55,11 @@ class SpecsUpdatesAgent:
         # Command: oq_transform
         subparsers.add_parser("oq_transform", help="Transform decided OQs into PUs")
 
+        # Command: oq_delete
+        oq_delete_parser = subparsers.add_parser("oq_delete", help="Delete an OQ and mark its artifact IRRELEVANT")
+        oq_delete_parser.add_argument("oq_id", help="OQ ID")
+        oq_delete_parser.add_argument("--yes", action="store_true", help="Confirm delete without prompt")
+
         # Command: approve_pu
         pu_app_parser = subparsers.add_parser("approve_pu", help="Approve a Proposed Update")
         pu_app_parser.add_argument("pu_id", help="PU ID")
@@ -60,6 +67,11 @@ class SpecsUpdatesAgent:
         # Command: init_sync
         init_parser = subparsers.add_parser("init_sync", help="Initialize the sync timestamp to current time to skip history")
         init_parser.add_argument("--channel", help="Specific channel ID to initialize (optional, uses .env or --channel)")
+
+        # Command: set_last_ts
+        set_ts_parser = subparsers.add_parser("set_last_ts", help="Set last_ts by days back from now")
+        set_ts_parser.add_argument("--channel", help="Specific channel ID to set (optional, uses .env or --channel)")
+        set_ts_parser.add_argument("--days", type=float, help="Number of days back (e.g. 3)")
 
         # Command: reset_data
         reset_parser = subparsers.add_parser("reset_data", help="Reset stored JSON data")
@@ -102,9 +114,13 @@ class SpecsUpdatesAgent:
         artifacts_created = result.artifacts_created
 
         if artifacts_created > 0:
-            print(f"Successfully created {artifacts_created} new artifacts.")
+            print(
+                "Successfully created "
+                f"{artifacts_created} new artifacts "
+                f"(OQ: {result.oq_count}, PU: {result.pu_count}, IRRELEVANT: {result.irrelevant_count})."
+            )
         else:
-            print("No new relevant artifacts found in the ingested threads.")
+            print("No new artifacts found in the ingested threads.")
 
     def cmd_change_status(self, args):
         status_choices = {"OQ", "PU", "IRRELEVANT"}
@@ -161,6 +177,21 @@ class SpecsUpdatesAgent:
             return
 
         print(f"Decision saved for OQ {args.oq_id}.")
+
+    def cmd_oq_delete(self, args):
+        if not args.yes:
+            confirm = input(f"Delete OQ {args.oq_id} and mark its artifact IRRELEVANT? (y/n): ").strip().lower()
+            if confirm not in {"y", "yes"}:
+                print("Delete cancelled.")
+                return
+
+        use_case = build_delete_oq_use_case()
+        result = use_case.execute(args.oq_id)
+        if not result.deleted:
+            print(f"OQ {args.oq_id} not found.")
+            return
+
+        print(f"OQ {args.oq_id} deleted.")
 
     def cmd_approve_pu(self, args):
         print(f"Approving PU {args.pu_id}...")
@@ -224,6 +255,25 @@ class SpecsUpdatesAgent:
         
         print(f"Sync initialized for channel {channel_id} at timestamp {current_ts}.")
         print("Future 'ingest' commands will only fetch messages from this point forward.")
+
+    def cmd_set_last_ts(self, args):
+        channel_id = args.channel or os.getenv("SLACK_CHANNEL_ID", "general")
+        days = args.days
+        if days is None:
+            raw = input("Enter number of days back (e.g. 3): ").strip()
+            try:
+                days = float(raw)
+            except ValueError:
+                print("Invalid number of days.")
+                return
+
+        if days < 0:
+            print("Days must be a non-negative number.")
+            return
+
+        use_case = build_set_last_ts_use_case()
+        result = use_case.execute(channel_id, days)
+        print(f"Set last_ts for channel {channel_id} to {result.last_ts}.")
 
     def cmd_art_list(self, args):
         use_case = build_list_artifacts_use_case()

--- a/src/cli/wiring.py
+++ b/src/cli/wiring.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import os
+
 from src.adapters.slack_reader import normalize_thread
 
-from src.adapters.openai import OpenAILLMClassifier
+from src.adapters.openai import OpenAILLMClassifier, OpenAILLMDecision
 from src.adapters.repo_json import (
     JsonArtifactRepository,
     JsonOpenQuestionRepository,
@@ -19,12 +21,14 @@ from src.use_cases.transform_artifacts import TransformArtifactsUseCase
 from src.use_cases.transform_oq import TransformOQUseCase
 from src.use_cases.approve_pu import ApprovePUUseCase
 from src.use_cases.add_decision import AddDecisionUseCase
+from src.use_cases.build_decision_from_thread import BuildDecisionFromThreadUseCase
 from src.use_cases.modify_oq import ModifyOQUseCase
 from src.use_cases.change_artifact_status import (
     ChangeArtifactStatusUseCase,
     ChangeArtifactStatusBatchUseCase,
 )
 from src.use_cases.list_artifacts import ListArtifactsUseCase
+from src.use_cases.list_all_oq import ListAllOQUseCase
 from src.use_cases.list_open_questions import ListOpenQuestionsUseCase
 from src.use_cases.list_proposed_updates import ListProposedUpdatesUseCase
 from src.use_cases.init_sync import InitSyncUseCase
@@ -32,6 +36,11 @@ from src.use_cases.reset_data import ResetDataUseCase
 from src.use_cases.set_last_ts import SetLastTsUseCase
 from src.use_cases.delete_oq import DeleteOQUseCase, DeleteOQBatchUseCase
 from src.use_cases.publish_oq import PublishOQsUseCase
+
+
+def _parse_tech_team_user_ids() -> set[str]:
+    raw = os.getenv("TECH_TEAM_USER_IDS", "")
+    return {item.strip() for item in raw.split(",") if item.strip()}
 
 
 def build_ingest_use_case() -> IngestUseCase:
@@ -66,6 +75,20 @@ def build_add_decision_use_case() -> AddDecisionUseCase:
     return AddDecisionUseCase(oq_repo)
 
 
+def build_decision_from_thread_use_case() -> BuildDecisionFromThreadUseCase:
+    slack_adapter = SlackSDKThreadsAdapter()
+    llm_decider = OpenAILLMDecision()
+    oq_repo = JsonOpenQuestionRepository()
+    tech_team_user_ids = _parse_tech_team_user_ids()
+    return BuildDecisionFromThreadUseCase(
+        oq_repo,
+        slack_adapter,
+        llm_decider,
+        normalize_thread,
+        tech_team_user_ids,
+    )
+
+
 def build_modify_oq_use_case() -> ModifyOQUseCase:
     oq_repo = JsonOpenQuestionRepository()
     pu_repo = JsonProposedUpdateRepository()
@@ -90,6 +113,11 @@ def build_list_artifacts_use_case() -> ListArtifactsUseCase:
 def build_list_open_questions_use_case() -> ListOpenQuestionsUseCase:
     oq_repo = JsonOpenQuestionRepository()
     return ListOpenQuestionsUseCase(oq_repo)
+
+
+def build_list_all_oq_use_case() -> ListAllOQUseCase:
+    oq_repo = JsonOpenQuestionRepository()
+    return ListAllOQUseCase(oq_repo)
 
 
 def build_list_proposed_updates_use_case() -> ListProposedUpdatesUseCase:

--- a/src/cli/wiring.py
+++ b/src/cli/wiring.py
@@ -29,7 +29,7 @@ from src.use_cases.list_proposed_updates import ListProposedUpdatesUseCase
 from src.use_cases.init_sync import InitSyncUseCase
 from src.use_cases.reset_data import ResetDataUseCase
 from src.use_cases.set_last_ts import SetLastTsUseCase
-from src.use_cases.delete_oq import DeleteOQUseCase
+from src.use_cases.delete_oq import DeleteOQUseCase, DeleteOQBatchUseCase
 
 
 def build_ingest_use_case() -> IngestUseCase:
@@ -115,3 +115,10 @@ def build_delete_oq_use_case() -> DeleteOQUseCase:
     artifact_repo = JsonArtifactRepository()
     pu_repo = JsonProposedUpdateRepository()
     return DeleteOQUseCase(oq_repo, artifact_repo, pu_repo)
+
+
+def build_delete_oq_batch_use_case() -> DeleteOQBatchUseCase:
+    oq_repo = JsonOpenQuestionRepository()
+    artifact_repo = JsonArtifactRepository()
+    pu_repo = JsonProposedUpdateRepository()
+    return DeleteOQBatchUseCase(oq_repo, artifact_repo, pu_repo)

--- a/src/cli/wiring.py
+++ b/src/cli/wiring.py
@@ -13,6 +13,7 @@ from src.adapters.slack_sdk import SlackSDKThreadsAdapter
 from src.adapters.trace_json import JsonTraceabilityAdapter
 from src.adapters.sources_state_json import JsonSourcesStateAdapter
 from src.adapters.data_reset_json import JsonDataResetAdapter
+from src.adapters.slack_publish import SlackSDKPublishAdapter
 from src.use_cases.ingest import IngestUseCase
 from src.use_cases.transform_artifacts import TransformArtifactsUseCase
 from src.use_cases.transform_oq import TransformOQUseCase
@@ -30,6 +31,7 @@ from src.use_cases.init_sync import InitSyncUseCase
 from src.use_cases.reset_data import ResetDataUseCase
 from src.use_cases.set_last_ts import SetLastTsUseCase
 from src.use_cases.delete_oq import DeleteOQUseCase, DeleteOQBatchUseCase
+from src.use_cases.publish_oq import PublishOQsUseCase
 
 
 def build_ingest_use_case() -> IngestUseCase:
@@ -122,3 +124,9 @@ def build_delete_oq_batch_use_case() -> DeleteOQBatchUseCase:
     artifact_repo = JsonArtifactRepository()
     pu_repo = JsonProposedUpdateRepository()
     return DeleteOQBatchUseCase(oq_repo, artifact_repo, pu_repo)
+
+
+def build_publish_oqs_use_case() -> PublishOQsUseCase:
+    oq_repo = JsonOpenQuestionRepository()
+    slack_publish = SlackSDKPublishAdapter()
+    return PublishOQsUseCase(oq_repo, slack_publish)

--- a/src/cli/wiring.py
+++ b/src/cli/wiring.py
@@ -28,6 +28,8 @@ from src.use_cases.list_open_questions import ListOpenQuestionsUseCase
 from src.use_cases.list_proposed_updates import ListProposedUpdatesUseCase
 from src.use_cases.init_sync import InitSyncUseCase
 from src.use_cases.reset_data import ResetDataUseCase
+from src.use_cases.set_last_ts import SetLastTsUseCase
+from src.use_cases.delete_oq import DeleteOQUseCase
 
 
 def build_ingest_use_case() -> IngestUseCase:
@@ -101,3 +103,15 @@ def build_init_sync_use_case() -> InitSyncUseCase:
 def build_reset_data_use_case() -> ResetDataUseCase:
     reset_adapter = JsonDataResetAdapter()
     return ResetDataUseCase(reset_adapter)
+
+
+def build_set_last_ts_use_case() -> SetLastTsUseCase:
+    sources_state = JsonSourcesStateAdapter()
+    return SetLastTsUseCase(sources_state)
+
+
+def build_delete_oq_use_case() -> DeleteOQUseCase:
+    oq_repo = JsonOpenQuestionRepository()
+    artifact_repo = JsonArtifactRepository()
+    pu_repo = JsonProposedUpdateRepository()
+    return DeleteOQUseCase(oq_repo, artifact_repo, pu_repo)

--- a/src/cli/wiring.py
+++ b/src/cli/wiring.py
@@ -12,6 +12,7 @@ from src.adapters.repo_json import (
 from src.adapters.slack_sdk import SlackSDKThreadsAdapter
 from src.adapters.trace_json import JsonTraceabilityAdapter
 from src.adapters.sources_state_json import JsonSourcesStateAdapter
+from src.adapters.data_reset_json import JsonDataResetAdapter
 from src.use_cases.ingest import IngestUseCase
 from src.use_cases.transform_artifacts import TransformArtifactsUseCase
 from src.use_cases.transform_oq import TransformOQUseCase
@@ -26,6 +27,7 @@ from src.use_cases.list_artifacts import ListArtifactsUseCase
 from src.use_cases.list_open_questions import ListOpenQuestionsUseCase
 from src.use_cases.list_proposed_updates import ListProposedUpdatesUseCase
 from src.use_cases.init_sync import InitSyncUseCase
+from src.use_cases.reset_data import ResetDataUseCase
 
 
 def build_ingest_use_case() -> IngestUseCase:
@@ -94,3 +96,8 @@ def build_list_proposed_updates_use_case() -> ListProposedUpdatesUseCase:
 def build_init_sync_use_case() -> InitSyncUseCase:
     sources_state = JsonSourcesStateAdapter()
     return InitSyncUseCase(sources_state)
+
+
+def build_reset_data_use_case() -> ResetDataUseCase:
+    reset_adapter = JsonDataResetAdapter()
+    return ResetDataUseCase(reset_adapter)

--- a/src/domain/models.py
+++ b/src/domain/models.py
@@ -20,6 +20,9 @@ class Artifact:
     rephrasing: str
     rationale: str
     summary_of_context: str
+    source_channel_id: Optional[str] = None
+    source_thread_ts: Optional[str] = None
+    source_thread_url: Optional[str] = None
 
 
 @dataclass
@@ -36,6 +39,9 @@ class OpenQuestion:
     published_message_ts: Optional[str] = None
     published_channel_id: Optional[str] = None
     last_modified_at: Optional[str] = None
+    source_channel_id: Optional[str] = None
+    source_thread_ts: Optional[str] = None
+    source_thread_url: Optional[str] = None
 
 
 @dataclass
@@ -48,6 +54,9 @@ class ProposedUpdate:
     decision: str
     rationale: str
     status: str
+    source_channel_id: Optional[str] = None
+    source_thread_ts: Optional[str] = None
+    source_thread_url: Optional[str] = None
 
 
 @dataclass

--- a/src/domain/models.py
+++ b/src/domain/models.py
@@ -32,6 +32,10 @@ class OpenQuestion:
     slack_ts: Optional[str] = None
     decision: Optional[str] = None
     decision_rationale: Optional[str] = None
+    published_at: Optional[str] = None
+    published_message_ts: Optional[str] = None
+    published_channel_id: Optional[str] = None
+    last_modified_at: Optional[str] = None
 
 
 @dataclass

--- a/src/ports/data_reset.py
+++ b/src/ports/data_reset.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class DataResetPort(Protocol):
+    def reset_all(self) -> None:
+        ...

--- a/src/ports/llm.py
+++ b/src/ports/llm.py
@@ -6,3 +6,8 @@ from typing import Protocol
 class LLMClassifierPort(Protocol):
     def classify(self, conversation_text: str) -> dict | None:
         ...
+
+
+class LLMDecisionPort(Protocol):
+    def decide(self, question: str, context: str, thread_text: str) -> dict | None:
+        ...

--- a/src/ports/repositories.py
+++ b/src/ports/repositories.py
@@ -29,6 +29,9 @@ class OpenQuestionRepository(Protocol):
     def create_from_artifact(self, artifact: Artifact) -> OpenQuestion:
         ...
 
+    def delete_by_id(self, oq_id: str) -> None:
+        ...
+
 
 class ProposedUpdateRepository(Protocol):
     def list_all(self) -> Iterable[ProposedUpdate]:

--- a/src/ports/slack.py
+++ b/src/ports/slack.py
@@ -6,3 +6,6 @@ from typing import Protocol
 class SlackThreadsPort(Protocol):
     def fetch_threads(self, channel_id: str) -> list[dict]:
         ...
+
+    def fetch_thread(self, channel_id: str, thread_ts: str) -> dict | None:
+        ...

--- a/src/ports/slack_publish.py
+++ b/src/ports/slack_publish.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class SlackPublishPort(Protocol):
+    def post_message(self, channel_id: str, text: str) -> str:
+        ...
+
+    def update_message(self, channel_id: str, message_ts: str, text: str) -> str:
+        ...

--- a/src/prompts/classify_discussion.txt
+++ b/src/prompts/classify_discussion.txt
@@ -1,6 +1,6 @@
 You are an expert software product analyst specialized in functional specifications, technical architecture, and engineering documentation.
 
-Your role is to analyze a single normalized conversation and determine whether it produces a meaningful artifact for project specifications.
+Your role is to analyze a single normalized conversation and determine whether it produces a meaningful artifact for product or technical specifications of a software project.
 
 Your task is to classify this conversation following the procedure below.
 
@@ -8,7 +8,7 @@ Your task is to classify this conversation following the procedure below.
 CLASSIFICATION PROCEDURE
 --------------------------------
 
-1. Determine whether the conversation is related to project specifications.
+1. Determine whether the conversation is related to product or technical specifications.
 A conversation is considered "related to specifications" if it concerns at least one of:
 - Functional behavior
 - Technical implementation
@@ -20,20 +20,22 @@ A conversation is considered "related to specifications" if it concerns at least
 If NOT related -> classify as IRRELEVANT.
 
 2. If related to specifications:
-2.1 Does it explicitly contain a question? (Check for "?" or interrogative form)
+2.1 Does the first message explicitly contain a question? (Check for "?" or interrogative form)
 If YES -> classify as OQ.
 
-2.2 If NO explicit question, does it contain a HIDDEN question?
+2.2 If NO explicit question related to specifications, does it contain a HIDDEN question?
 (Implicitly asks for validation, decision, missing spec, or clarification)
 If YES -> classify as OQ.
 
-2.3 Otherwise -> classify as PU.
+2.3 if NO hidden question, do the replies contain a question related to specifications ?
+if YES -> classify as OQ
+
+2.3 Otherwise -> classify as IRRELEVANT.
 
 --------------------------------
 OUTPUT RULES
 --------------------------------
-- Choose exactly one type: "OQ", "PU", or "IRRELEVANT".
-- Prefer OQ over PU when uncertain.
+- Choose exactly one type: "OQ" or "IRRELEVANT".
 - Return valid JSON only.
 - You MUST provide a "rationale" explaining your classification choice.
 
@@ -41,7 +43,7 @@ OUTPUT RULES
 OUTPUT FORMAT
 --------------------------------
 {
-  "type": "OQ" | "PU" | "IRRELEVANT",
+  "type": "OQ" | "IRRELEVANT",
   "rephrasing": "<clear reformulation or empty string if IRRELEVANT>",
   "rationale": "<explanation of why this classification was chosen>",
   "summary_of_context": "<optional concise summary>"

--- a/src/prompts/decision_from_thread.txt
+++ b/src/prompts/decision_from_thread.txt
@@ -1,0 +1,21 @@
+You are an expert software product analyst specialized in functional specifications, technical architecture, and engineering documentation.
+
+You are given:
+Open Question:
+{{question}}
+
+Context:
+{{context}}
+
+Thread replies from the technical team:
+{{thread}}
+
+Task:
+- Determine the most appropriate decision based strictly on the replies.
+- Provide a concise decision rationale citing the key points from the thread.
+
+If the replies are insufficient or conflicting, choose the safest decision and explicitly state the uncertainty in the rationale.
+
+Return ONLY a JSON object with exactly these keys:
+- decision (string)
+- decision_rationale (string)

--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -1,0 +1,1 @@
+"""UI package for the Specs Updates Generator."""

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -1,0 +1,519 @@
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import asdict
+from typing import Callable, Iterable, Sequence
+
+from dotenv import load_dotenv
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QApplication,
+    QAbstractItemView,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QHBoxLayout,
+    QHeaderView,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QSplitter,
+    QTabWidget,
+    QTableWidget,
+    QTableWidgetItem,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.cli.wiring import (
+    build_add_decision_use_case,
+    build_approve_pu_use_case,
+    build_ingest_use_case,
+    build_list_artifacts_use_case,
+    build_list_open_questions_use_case,
+    build_list_proposed_updates_use_case,
+    build_transform_artifacts_use_case,
+    build_transform_oq_use_case,
+)
+
+
+MAX_CELL_LEN = 80
+
+
+def _fmt(value: object) -> str:
+    if value is None:
+        return "-"
+    text = str(value)
+    if text.strip() == "":
+        return "-"
+    return text
+
+
+def _truncate(value: object, limit: int = MAX_CELL_LEN) -> str:
+    text = _fmt(value)
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."
+
+
+class DecisionDialog(QDialog):
+    def __init__(self, parent: QWidget | None = None, decision: str = "", rationale: str = "") -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Add Decision")
+
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+
+        self.decision_edit = QLineEdit(decision)
+        self.rationale_edit = QTextEdit()
+        self.rationale_edit.setPlainText(rationale)
+        self.rationale_edit.setFixedHeight(120)
+
+        form.addRow("Decision", self.decision_edit)
+        form.addRow("Rationale", self.rationale_edit)
+
+        layout.addLayout(form)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def values(self) -> tuple[str, str]:
+        return self.decision_edit.text().strip(), self.rationale_edit.toPlainText().strip()
+
+
+class RecordsTab(QWidget):
+    def __init__(
+        self,
+        title: str,
+        columns: Sequence[tuple[str, Callable[[object], object]]],
+        load_records: Callable[[], Iterable[object]],
+        format_details: Callable[[object], str],
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.title = title
+        self.columns = list(columns)
+        self.load_records = load_records
+        self.format_details = format_details
+        self.records: list[object] = []
+        self._all_records: list[object] = []
+
+        layout = QVBoxLayout(self)
+        top_bar = QHBoxLayout()
+        self.count_label = QLabel("Count: 0")
+        top_bar.addWidget(self.count_label)
+        top_bar.addStretch()
+        top_bar.addWidget(QLabel("Filter"))
+        self.filter_input = QLineEdit()
+        self.filter_input.setPlaceholderText("Type to filter…")
+        self.filter_input.textChanged.connect(self._apply_filter)
+        top_bar.addWidget(self.filter_input)
+        layout.addLayout(top_bar)
+
+        splitter = QSplitter(Qt.Horizontal)
+
+        self.table = QTableWidget(0, len(self.columns))
+        self.table.setHorizontalHeaderLabels([label for label, _ in self.columns])
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.table.horizontalHeader().setStretchLastSection(True)
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
+        self.table.verticalHeader().setVisible(False)
+        self.table.itemSelectionChanged.connect(self._on_selection_changed)
+
+        splitter.addWidget(self.table)
+
+        details_panel = QWidget()
+        details_layout = QVBoxLayout(details_panel)
+        details_layout.setContentsMargins(0, 0, 0, 0)
+        details_layout.addWidget(QLabel("Details"))
+
+        self.details = QTextEdit()
+        self.details.setReadOnly(True)
+        details_layout.addWidget(self.details)
+
+        splitter.addWidget(details_panel)
+        splitter.setStretchFactor(0, 3)
+        splitter.setStretchFactor(1, 2)
+
+        layout.addWidget(splitter)
+
+    def refresh(self) -> None:
+        try:
+            self._all_records = list(self.load_records())
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            self._all_records = []
+            self._show_error(f"Failed to load {self.title}: {exc}")
+
+        self._apply_filter(self.filter_input.text())
+
+    def selected_record(self) -> object | None:
+        selected_rows = self.table.selectionModel().selectedRows()
+        if not selected_rows:
+            return None
+        row = selected_rows[0].row()
+        if row < 0 or row >= len(self.records):
+            return None
+        return self.records[row]
+
+    def selected_id(self) -> str | None:
+        record = self.selected_record()
+        if record is None:
+            return None
+        data = asdict(record)
+        return str(data.get("id")) if data.get("id") else None
+
+    def _on_selection_changed(self) -> None:
+        record = self.selected_record()
+        self._update_details(record)
+
+    def _update_details(self, record: object | None) -> None:
+        if record is None:
+            self.details.setPlainText("Select a row to see details.")
+            return
+        self.details.setPlainText(self.format_details(record))
+
+    def _apply_filter(self, text: str) -> None:
+        query = text.strip().lower()
+        if query == "":
+            self.records = list(self._all_records)
+        else:
+            self.records = [record for record in self._all_records if self._matches(record, query)]
+        self._render_records()
+
+    def _matches(self, record: object, query: str) -> bool:
+        for _, getter in self.columns:
+            value = _fmt(getter(record)).lower()
+            if query in value:
+                return True
+        return False
+
+    def _render_records(self) -> None:
+        self.table.setRowCount(len(self.records))
+        for row_index, record in enumerate(self.records):
+            for col_index, (_, getter) in enumerate(self.columns):
+                value = _truncate(getter(record))
+                item = QTableWidgetItem(value)
+                item.setToolTip(_fmt(getter(record)))
+                item.setTextAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+                self.table.setItem(row_index, col_index, item)
+
+        total = len(self._all_records)
+        shown = len(self.records)
+        if self.filter_input.text().strip():
+            self.count_label.setText(f"Count: {shown} (filtered from {total})")
+        else:
+            self.count_label.setText(f"Count: {shown}")
+
+        self.table.clearSelection()
+        self._update_details(None)
+
+    def _show_error(self, message: str) -> None:
+        QMessageBox.critical(self, "Error", message)
+
+
+class MainWindow(QMainWindow):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Specs Updates UI")
+        self.resize(1200, 800)
+
+        central = QWidget()
+        layout = QVBoxLayout(central)
+
+        actions_layout = QHBoxLayout()
+
+        self.ingest_button = QPushButton("Ingest")
+        self.ingest_button.clicked.connect(self.handle_ingest)
+        actions_layout.addWidget(self.ingest_button)
+
+        self.transform_artifacts_button = QPushButton("Transform Artifacts")
+        self.transform_artifacts_button.clicked.connect(self.handle_transform_artifacts)
+        actions_layout.addWidget(self.transform_artifacts_button)
+
+        self.transform_oq_button = QPushButton("Transform OQs")
+        self.transform_oq_button.clicked.connect(self.handle_transform_oq)
+        actions_layout.addWidget(self.transform_oq_button)
+
+        self.decide_oq_button = QPushButton("Decide OQ")
+        self.decide_oq_button.clicked.connect(self.handle_decide_oq)
+        actions_layout.addWidget(self.decide_oq_button)
+
+        self.approve_pu_button = QPushButton("Approve PU")
+        self.approve_pu_button.clicked.connect(self.handle_approve_pu)
+        actions_layout.addWidget(self.approve_pu_button)
+
+        self.refresh_button = QPushButton("Refresh")
+        self.refresh_button.clicked.connect(self.refresh_all)
+        actions_layout.addWidget(self.refresh_button)
+
+        actions_layout.addStretch()
+        layout.addLayout(actions_layout)
+
+        self.tabs = QTabWidget()
+        layout.addWidget(self.tabs)
+
+        self.setCentralWidget(central)
+
+        self._build_tabs()
+        self.refresh_all()
+
+    def _build_tabs(self) -> None:
+        self.artifacts_tab = RecordsTab(
+            title="Artifacts",
+            columns=[
+                ("ID", lambda a: a.id),
+                ("Type", lambda a: a.type.value if hasattr(a.type, "value") else a.type),
+                ("Status", lambda a: a.status),
+                ("Rephrasing", lambda a: a.rephrasing),
+            ],
+            load_records=self._load_artifacts,
+            format_details=_format_artifact_details,
+        )
+        self.tabs.addTab(self.artifacts_tab, "Artifacts")
+
+        self.oq_tab = RecordsTab(
+            title="Open Questions",
+            columns=[
+                ("ID", lambda o: o.id),
+                ("Status", lambda o: o.status),
+                ("Question", lambda o: o.question),
+                ("Decision", lambda o: o.decision),
+            ],
+            load_records=self._load_open_questions,
+            format_details=_format_open_question_details,
+        )
+        self.tabs.addTab(self.oq_tab, "Open Questions")
+
+        self.pu_tab = RecordsTab(
+            title="Proposed Updates",
+            columns=[
+                ("ID", lambda p: p.id),
+                ("Status", lambda p: p.status),
+                ("Rephrasing", lambda p: p.rephrasing),
+                ("Decision", lambda p: p.decision),
+            ],
+            load_records=self._load_proposed_updates,
+            format_details=_format_proposed_update_details,
+        )
+        self.tabs.addTab(self.pu_tab, "Proposed Updates")
+
+    def refresh_all(self) -> None:
+        self.artifacts_tab.refresh()
+        self.oq_tab.refresh()
+        self.pu_tab.refresh()
+        self.statusBar().showMessage("Data refreshed", 3000)
+
+    def handle_ingest(self) -> None:
+        default_channel = os.getenv("SLACK_CHANNEL_ID", "general")
+        channel, ok = QInputDialog.getText(
+            self,
+            "Ingest",
+            "Slack channel ID",
+            text=default_channel,
+        )
+        if not ok or channel.strip() == "":
+            return
+
+        try:
+            ingest_use_case = build_ingest_use_case()
+            result = ingest_use_case.execute(channel.strip())
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            QMessageBox.critical(self, "Ingest failed", str(exc))
+            return
+
+        if result.threads_fetched == 0:
+            QMessageBox.information(self, "Ingest", "No new threads found.")
+        else:
+            message = (
+                f"Created {result.artifacts_created} artifacts. "
+                f"OQ: {result.oq_count}, PU: {result.pu_count}, "
+                f"IRRELEVANT: {result.irrelevant_count}."
+            )
+            QMessageBox.information(self, "Ingest", message)
+
+        self.refresh_all()
+
+    def handle_transform_artifacts(self) -> None:
+        try:
+            use_case = build_transform_artifacts_use_case()
+            oq_count, pu_count = use_case.execute()
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            QMessageBox.critical(self, "Transform failed", str(exc))
+            return
+
+        QMessageBox.information(
+            self,
+            "Transform Artifacts",
+            f"Created {oq_count} OQ and {pu_count} PU.",
+        )
+        self.refresh_all()
+
+    def handle_transform_oq(self) -> None:
+        try:
+            use_case = build_transform_oq_use_case()
+            result = use_case.execute()
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            QMessageBox.critical(self, "Transform failed", str(exc))
+            return
+
+        QMessageBox.information(
+            self,
+            "Transform OQs",
+            f"Created {result.transformed_count} proposed updates.",
+        )
+        self.refresh_all()
+
+    def handle_decide_oq(self) -> None:
+        oq_id = self.oq_tab.selected_id()
+        if not oq_id:
+            QMessageBox.information(self, "Decide OQ", "Select an OQ first.")
+            return
+
+        dialog = DecisionDialog(self)
+        if dialog.exec() != QDialog.Accepted:
+            return
+
+        decision, rationale = dialog.values()
+        if decision == "" or rationale == "":
+            QMessageBox.warning(self, "Decide OQ", "Decision and rationale are required.")
+            return
+
+        try:
+            use_case = build_add_decision_use_case()
+            result = use_case.execute(oq_id, decision, rationale)
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            QMessageBox.critical(self, "Decide OQ", str(exc))
+            return
+
+        if not result.updated:
+            QMessageBox.warning(self, "Decide OQ", f"OQ {oq_id} not found.")
+        else:
+            QMessageBox.information(self, "Decide OQ", f"Decision saved for {oq_id}.")
+            self.refresh_all()
+
+    def handle_approve_pu(self) -> None:
+        pu_id = self.pu_tab.selected_id()
+        if not pu_id:
+            QMessageBox.information(self, "Approve PU", "Select a proposed update first.")
+            return
+
+        try:
+            use_case = build_approve_pu_use_case()
+            result = use_case.execute(pu_id)
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            QMessageBox.critical(self, "Approve PU", str(exc))
+            return
+
+        if result.spec_update is None:
+            QMessageBox.warning(self, "Approve PU", f"PU {pu_id} not found.")
+            return
+
+        remaining = result.remaining_drafts
+        message = f"Approved {pu_id}. Remaining drafts: {remaining}."
+        QMessageBox.information(self, "Approve PU", message)
+        self.refresh_all()
+
+    @staticmethod
+    def _load_artifacts() -> Iterable[object]:
+        use_case = build_list_artifacts_use_case()
+        return use_case.execute()
+
+    @staticmethod
+    def _load_open_questions() -> Iterable[object]:
+        use_case = build_list_open_questions_use_case()
+        return use_case.execute()
+
+    @staticmethod
+    def _load_proposed_updates() -> Iterable[object]:
+        use_case = build_list_proposed_updates_use_case()
+        return use_case.execute()
+
+
+def _format_artifact_details(artifact: object) -> str:
+    data = asdict(artifact)
+    artifact_type = data.get("type")
+    if hasattr(artifact_type, "value"):
+        artifact_type = artifact_type.value
+    lines = [
+        f"ID: {_fmt(data.get('id'))}",
+        f"Conversation ID: {_fmt(data.get('conversation_id'))}",
+        f"Type: {_fmt(artifact_type)}",
+        f"Status: {_fmt(data.get('status'))}",
+        "",
+        "Rephrasing:",
+        _fmt(data.get("rephrasing")),
+        "",
+        "Rationale:",
+        _fmt(data.get("rationale")),
+        "",
+        "Summary of context:",
+        _fmt(data.get("summary_of_context")),
+    ]
+    return "\n".join(lines)
+
+
+def _format_open_question_details(oq: object) -> str:
+    data = asdict(oq)
+    lines = [
+        f"ID: {_fmt(data.get('id'))}",
+        f"Artifact ID: {_fmt(data.get('artifact_id'))}",
+        f"Status: {_fmt(data.get('status'))}",
+        f"Slack TS: {_fmt(data.get('slack_ts'))}",
+        "",
+        "Question:",
+        _fmt(data.get("question")),
+        "",
+        "Context:",
+        _fmt(data.get("context")),
+        "",
+        "Decision:",
+        _fmt(data.get("decision")),
+        "",
+        "Decision rationale:",
+        _fmt(data.get("decision_rationale")),
+    ]
+    return "\n".join(lines)
+
+
+def _format_proposed_update_details(pu: object) -> str:
+    data = asdict(pu)
+    lines = [
+        f"ID: {_fmt(data.get('id'))}",
+        f"Artifact ID: {_fmt(data.get('artifact_id'))}",
+        f"Source OQ ID: {_fmt(data.get('source_oq_id'))}",
+        f"Status: {_fmt(data.get('status'))}",
+        "",
+        "Rephrasing:",
+        _fmt(data.get("rephrasing")),
+        "",
+        "Context:",
+        _fmt(data.get("context")),
+        "",
+        "Decision:",
+        _fmt(data.get("decision")),
+        "",
+        "Rationale:",
+        _fmt(data.get("rationale")),
+    ]
+    return "\n".join(lines)
+
+
+def main() -> None:
+    load_dotenv(override=True)
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -37,6 +37,7 @@ from src.cli.wiring import (
     build_add_decision_use_case,
     build_approve_pu_use_case,
     build_change_artifact_status_use_case,
+    build_decision_from_thread_use_case,
     build_delete_oq_use_case,
     build_ingest_use_case,
     build_list_artifacts_use_case,
@@ -375,7 +376,7 @@ class MainWindow(QMainWindow):
         self.transform_oq_button.clicked.connect(self.handle_transform_oq)
         actions_layout.addWidget(self.transform_oq_button)
 
-        self.decide_oq_button = QPushButton("Decide OQ")
+        self.decide_oq_button = QPushButton("Manual Decision")
         self.decide_oq_button.clicked.connect(self.handle_decide_oq)
         actions_layout.addWidget(self.decide_oq_button)
 
@@ -445,7 +446,8 @@ class MainWindow(QMainWindow):
             load_records=self._load_open_questions,
             format_details=_format_open_question_details,
             details_actions=[
-                ("Decide OQ", self.handle_decide_oq),
+                ("Manual Decision", self.handle_decide_oq),
+                ("Build decision", self.handle_build_decision),
                 ("Modify OQ", self.handle_modify_oq),
                 ("Publish OQ", self.handle_publish_oq),
                 ("Delete OQ", self.handle_delete_oq),
@@ -651,7 +653,7 @@ class MainWindow(QMainWindow):
     def handle_decide_oq(self) -> None:
         record = self.oq_tab.selected_record()
         if record is None:
-            QMessageBox.information(self, "Decide OQ", "Select an OQ first.")
+            QMessageBox.information(self, "Manual Decision", "Select an OQ first.")
             return
         oq_id = str(record.id)
 
@@ -669,14 +671,65 @@ class MainWindow(QMainWindow):
             use_case = build_add_decision_use_case()
             result = use_case.execute(oq_id, decision, rationale)
         except Exception as exc:  # pragma: no cover - UI feedback only
-            QMessageBox.critical(self, "Decide OQ", str(exc))
+            QMessageBox.critical(self, "Manual Decision", str(exc))
             return
 
         if not result.updated:
-            QMessageBox.warning(self, "Decide OQ", f"OQ {oq_id} not found.")
+            QMessageBox.warning(self, "Manual Decision", f"OQ {oq_id} not found.")
         else:
-            QMessageBox.information(self, "Decide OQ", f"Decision saved for {oq_id}.")
+            QMessageBox.information(self, "Manual Decision", f"Decision saved for {oq_id}.")
             self.refresh_all()
+
+    def handle_build_decision(self) -> None:
+        record = self.oq_tab.selected_record()
+        if record is None:
+            QMessageBox.information(self, "Build decision", "Select an OQ first.")
+            return
+
+        if not record.published_channel_id or not record.published_message_ts:
+            QMessageBox.warning(
+                self,
+                "Build decision",
+                "OQ must be published before building a decision from the thread.",
+            )
+            return
+
+        confirm = QMessageBox.question(
+            self,
+            "Confirm build decision",
+            f"Build decision for {record.id} using the Slack thread and LLM?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if confirm != QMessageBox.Yes:
+            return
+
+        try:
+            use_case = build_decision_from_thread_use_case()
+            result = use_case.execute(str(record.id))
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            QMessageBox.critical(self, "Build decision", str(exc))
+            return
+
+        if not result.updated:
+            reason = result.reason or "unknown"
+            reason_map = {
+                "missing_oq": "OQ not found.",
+                "not_published": "OQ must be published before building a decision.",
+                "thread_missing": "Slack thread not found or empty.",
+                "no_tech_messages": "No eligible replies found in the thread.",
+                "llm_failed": "Decision model failed to produce a result.",
+                "empty_decision": "Decision result was empty.",
+            }
+            QMessageBox.warning(self, "Build decision", reason_map.get(reason, f"Failed: {reason}"))
+            return
+
+        QMessageBox.information(
+            self,
+            "Build decision",
+            f"Decision built and saved for {record.id}. Messages used: {result.messages_used}.",
+        )
+        self.refresh_all()
 
     def handle_modify_oq(self) -> None:
         record = self.oq_tab.selected_record()

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 import os
 import sys
 from dataclasses import asdict
@@ -13,6 +14,7 @@ from PySide6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QFormLayout,
+    QFrame,
     QHBoxLayout,
     QHeaderView,
     QInputDialog,
@@ -25,6 +27,7 @@ from PySide6.QtWidgets import (
     QTabWidget,
     QTableWidget,
     QTableWidgetItem,
+    QTextBrowser,
     QTextEdit,
     QVBoxLayout,
     QWidget,
@@ -33,13 +36,16 @@ from PySide6.QtWidgets import (
 from src.cli.wiring import (
     build_add_decision_use_case,
     build_approve_pu_use_case,
+    build_change_artifact_status_use_case,
     build_delete_oq_use_case,
     build_ingest_use_case,
     build_list_artifacts_use_case,
-    build_list_open_questions_use_case,
+    build_list_all_oq_use_case,
     build_list_proposed_updates_use_case,
     build_modify_oq_use_case,
     build_publish_oqs_use_case,
+    build_reset_data_use_case,
+    build_set_last_ts_use_case,
     build_transform_artifacts_use_case,
     build_transform_oq_use_case,
 )
@@ -62,6 +68,19 @@ def _truncate(value: object, limit: int = MAX_CELL_LEN) -> str:
     if len(text) <= limit:
         return text
     return text[: limit - 3] + "..."
+
+def _fmt_html(value: object) -> str:
+    return html.escape(_fmt(value))
+
+
+def _link_html(url: object) -> str:
+    if url is None:
+        return "-"
+    text = str(url).strip()
+    if text == "" or text == "-":
+        return "-"
+    safe = html.escape(text)
+    return f'<a href="{safe}">{safe}</a>'
 
 
 class DecisionDialog(QDialog):
@@ -192,7 +211,8 @@ class RecordsTab(QWidget):
         details_layout.setContentsMargins(0, 0, 0, 0)
         details_layout.addWidget(QLabel("Details"))
 
-        self.details = QTextEdit()
+        self.details = QTextBrowser()
+        self.details.setOpenExternalLinks(True)
         self.details.setReadOnly(True)
         details_layout.addWidget(self.details)
 
@@ -250,10 +270,10 @@ class RecordsTab(QWidget):
 
     def _update_details(self, record: object | None) -> None:
         if record is None:
-            self.details.setPlainText("Select a row to see details.")
+            self.details.setHtml(_fmt_html("Select a row to see details."))
             self._set_actions_enabled(False)
             return
-        self.details.setPlainText(self.format_details(record))
+        self.details.setHtml(self.format_details(record))
         self._set_actions_enabled(True)
 
     def _set_actions_enabled(self, enabled: bool) -> None:
@@ -372,6 +392,21 @@ class MainWindow(QMainWindow):
         actions_layout.addWidget(self.refresh_button)
 
         actions_layout.addStretch()
+
+        system_separator = QFrame()
+        system_separator.setFrameShape(QFrame.VLine)
+        system_separator.setFrameShadow(QFrame.Sunken)
+        system_separator.setFixedHeight(24)
+        actions_layout.addWidget(system_separator)
+
+        self.reset_data_button = QPushButton("Clear Data")
+        self.reset_data_button.clicked.connect(self.handle_reset_data)
+        actions_layout.addWidget(self.reset_data_button)
+
+        self.set_last_ts_button = QPushButton("Set last_ts")
+        self.set_last_ts_button.clicked.connect(self.handle_set_last_ts)
+        actions_layout.addWidget(self.set_last_ts_button)
+
         layout.addLayout(actions_layout)
 
         self.tabs = QTabWidget()
@@ -393,11 +428,14 @@ class MainWindow(QMainWindow):
             ],
             load_records=self._load_artifacts,
             format_details=_format_artifact_details,
+            details_actions=[
+                ("Change Status", self.handle_change_artifact_status),
+            ],
         )
         self.tabs.addTab(self.artifacts_tab, "Artifacts")
 
         self.oq_tab = RecordsTab(
-            title="Open Questions",
+            title="Open Questions (All)",
             columns=[
                 ("ID", lambda o: o.id),
                 ("Status", lambda o: o.status),
@@ -413,7 +451,7 @@ class MainWindow(QMainWindow):
                 ("Delete OQ", self.handle_delete_oq),
             ],
         )
-        self.tabs.addTab(self.oq_tab, "Open Questions")
+        self.tabs.addTab(self.oq_tab, "Open Questions (All)")
 
         self.pu_tab = RecordsTab(
             title="Proposed Updates",
@@ -493,6 +531,122 @@ class MainWindow(QMainWindow):
             f"Created {result.transformed_count} proposed updates.",
         )
         self.refresh_all()
+
+    def handle_reset_data(self) -> None:
+        confirm = QMessageBox.question(
+            self,
+            "Confirm Clear Data",
+            "Clear all stored data (artifacts, questions, updates, threads, conversations)?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if confirm != QMessageBox.Yes:
+            return
+
+        try:
+            use_case = build_reset_data_use_case()
+            result = use_case.execute()
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            QMessageBox.critical(self, "Clear Data", str(exc))
+            return
+
+        if result.success:
+            QMessageBox.information(self, "Clear Data", "Data cleared.")
+            self.refresh_all()
+        else:
+            QMessageBox.warning(self, "Clear Data", "Data was not cleared.")
+
+    def handle_set_last_ts(self) -> None:
+        default_channel = os.getenv("SLACK_CHANNEL_ID", "general")
+        channel, ok = QInputDialog.getText(
+            self,
+            "Set last_ts",
+            "Slack channel ID",
+            text=default_channel,
+        )
+        if not ok or channel.strip() == "":
+            return
+
+        days_back, ok = QInputDialog.getDouble(
+            self,
+            "Set last_ts",
+            "Days back from now",
+            3.0,
+            0.0,
+            3650.0,
+            2,
+        )
+        if not ok:
+            return
+
+        confirm = QMessageBox.question(
+            self,
+            "Confirm set last_ts",
+            f"Set last_ts for {channel.strip()} to {days_back} day(s) back?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if confirm != QMessageBox.Yes:
+            return
+
+        try:
+            use_case = build_set_last_ts_use_case()
+            result = use_case.execute(channel.strip(), days_back)
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            QMessageBox.critical(self, "Set last_ts", str(exc))
+            return
+
+        QMessageBox.information(
+            self,
+            "Set last_ts",
+            f"last_ts set for {result.channel_id} to {result.last_ts}.",
+        )
+
+    def handle_change_artifact_status(self) -> None:
+        record = self.artifacts_tab.selected_record()
+        if record is None:
+            QMessageBox.information(self, "Change Status", "Select an artifact first.")
+            return
+
+        choices = ["OQ", "PU", "IRRELEVANT"]
+        current = record.status if record.status in choices else None
+        status, ok = QInputDialog.getItem(
+            self,
+            "Change Status",
+            f"Artifact {record.id} status",
+            choices,
+            choices.index(current) if current in choices else 0,
+            False,
+        )
+        if not ok or status.strip() == "":
+            return
+
+        if status == record.status:
+            QMessageBox.information(self, "Change Status", "Status is unchanged.")
+            return
+
+        confirm = QMessageBox.question(
+            self,
+            "Confirm status change",
+            f"Change status of {record.id} to {status}?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if confirm != QMessageBox.Yes:
+            return
+
+        try:
+            use_case = build_change_artifact_status_use_case()
+            result = use_case.execute(record.id, status)
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            QMessageBox.critical(self, "Change Status", str(exc))
+            return
+
+        if not result.updated:
+            QMessageBox.warning(self, "Change Status", f"Artifact {record.id} not found.")
+        else:
+            QMessageBox.information(self, "Change Status", f"Status updated for {record.id}.")
+            self.refresh_all()
 
     def handle_decide_oq(self) -> None:
         record = self.oq_tab.selected_record()
@@ -744,7 +898,7 @@ class MainWindow(QMainWindow):
 
     @staticmethod
     def _load_open_questions() -> Iterable[object]:
-        use_case = build_list_open_questions_use_case()
+        use_case = build_list_all_oq_use_case()
         return use_case.execute()
 
     @staticmethod
@@ -759,67 +913,76 @@ def _format_artifact_details(artifact: object) -> str:
     if hasattr(artifact_type, "value"):
         artifact_type = artifact_type.value
     lines = [
-        f"ID: {_fmt(data.get('id'))}",
-        f"Conversation ID: {_fmt(data.get('conversation_id'))}",
-        f"Type: {_fmt(artifact_type)}",
-        f"Status: {_fmt(data.get('status'))}",
+        f"<b>ID:</b> {_fmt_html(data.get('id'))}",
+        f"<b>Conversation ID:</b> {_fmt_html(data.get('conversation_id'))}",
+        f"<b>Type:</b> {_fmt_html(artifact_type)}",
+        f"<b>Status:</b> {_fmt_html(data.get('status'))}",
+        f"<b>Thread URL:</b> {_link_html(data.get('source_thread_url'))}",
+        f"<b>Channel ID:</b> {_fmt_html(data.get('source_channel_id'))}",
+        f"<b>Thread TS:</b> {_fmt_html(data.get('source_thread_ts'))}",
         "",
-        "Rephrasing:",
-        _fmt(data.get("rephrasing")),
+        "<b>Rephrasing:</b>",
+        _fmt_html(data.get("rephrasing")),
         "",
-        "Rationale:",
-        _fmt(data.get("rationale")),
+        "<b>Rationale:</b>",
+        _fmt_html(data.get("rationale")),
         "",
-        "Summary of context:",
-        _fmt(data.get("summary_of_context")),
+        "<b>Summary of context:</b>",
+        _fmt_html(data.get("summary_of_context")),
     ]
-    return "\n".join(lines)
+    return "<br>".join(lines)
 
 
 def _format_open_question_details(oq: object) -> str:
     data = asdict(oq)
     lines = [
-        f"ID: {_fmt(data.get('id'))}",
-        f"Artifact ID: {_fmt(data.get('artifact_id'))}",
-        f"Status: {_fmt(data.get('status'))}",
-        f"Slack TS: {_fmt(data.get('slack_ts'))}",
+        f"<b>ID:</b> {_fmt_html(data.get('id'))}",
+        f"<b>Artifact ID:</b> {_fmt_html(data.get('artifact_id'))}",
+        f"<b>Status:</b> {_fmt_html(data.get('status'))}",
+        f"<b>Slack TS:</b> {_fmt_html(data.get('slack_ts'))}",
+        f"<b>Thread URL:</b> {_link_html(data.get('source_thread_url'))}",
+        f"<b>Channel ID:</b> {_fmt_html(data.get('source_channel_id'))}",
+        f"<b>Thread TS:</b> {_fmt_html(data.get('source_thread_ts'))}",
         "",
-        "Question:",
-        _fmt(data.get("question")),
+        "<b>Question:</b>",
+        _fmt_html(data.get("question")),
         "",
-        "Context:",
-        _fmt(data.get("context")),
+        "<b>Context:</b>",
+        _fmt_html(data.get("context")),
         "",
-        "Decision:",
-        _fmt(data.get("decision")),
+        "<b>Decision:</b>",
+        _fmt_html(data.get("decision")),
         "",
-        "Decision rationale:",
-        _fmt(data.get("decision_rationale")),
+        "<b>Decision rationale:</b>",
+        _fmt_html(data.get("decision_rationale")),
     ]
-    return "\n".join(lines)
+    return "<br>".join(lines)
 
 
 def _format_proposed_update_details(pu: object) -> str:
     data = asdict(pu)
     lines = [
-        f"ID: {_fmt(data.get('id'))}",
-        f"Artifact ID: {_fmt(data.get('artifact_id'))}",
-        f"Source OQ ID: {_fmt(data.get('source_oq_id'))}",
-        f"Status: {_fmt(data.get('status'))}",
+        f"<b>ID:</b> {_fmt_html(data.get('id'))}",
+        f"<b>Artifact ID:</b> {_fmt_html(data.get('artifact_id'))}",
+        f"<b>Source OQ ID:</b> {_fmt_html(data.get('source_oq_id'))}",
+        f"<b>Status:</b> {_fmt_html(data.get('status'))}",
+        f"<b>Thread URL:</b> {_link_html(data.get('source_thread_url'))}",
+        f"<b>Channel ID:</b> {_fmt_html(data.get('source_channel_id'))}",
+        f"<b>Thread TS:</b> {_fmt_html(data.get('source_thread_ts'))}",
         "",
-        "Rephrasing:",
-        _fmt(data.get("rephrasing")),
+        "<b>Rephrasing:</b>",
+        _fmt_html(data.get("rephrasing")),
         "",
-        "Context:",
-        _fmt(data.get("context")),
+        "<b>Context:</b>",
+        _fmt_html(data.get("context")),
         "",
-        "Decision:",
-        _fmt(data.get("decision")),
+        "<b>Decision:</b>",
+        _fmt_html(data.get("decision")),
         "",
-        "Rationale:",
-        _fmt(data.get("rationale")),
+        "<b>Rationale:</b>",
+        _fmt_html(data.get("rationale")),
     ]
-    return "\n".join(lines)
+    return "<br>".join(lines)
 
 
 def main() -> None:

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -33,10 +33,13 @@ from PySide6.QtWidgets import (
 from src.cli.wiring import (
     build_add_decision_use_case,
     build_approve_pu_use_case,
+    build_delete_oq_use_case,
     build_ingest_use_case,
     build_list_artifacts_use_case,
     build_list_open_questions_use_case,
     build_list_proposed_updates_use_case,
+    build_modify_oq_use_case,
+    build_publish_oqs_use_case,
     build_transform_artifacts_use_case,
     build_transform_oq_use_case,
 )
@@ -88,6 +91,54 @@ class DecisionDialog(QDialog):
         return self.decision_edit.text().strip(), self.rationale_edit.toPlainText().strip()
 
 
+class EditOQDialog(QDialog):
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        question: str = "",
+        context: str = "",
+        decision: str = "",
+        rationale: str = "",
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Modify Open Question")
+
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+
+        self.question_edit = QLineEdit(question)
+
+        self.context_edit = QTextEdit()
+        self.context_edit.setPlainText(context)
+        self.context_edit.setFixedHeight(140)
+
+        self.decision_edit = QLineEdit(decision)
+
+        self.rationale_edit = QTextEdit()
+        self.rationale_edit.setPlainText(rationale)
+        self.rationale_edit.setFixedHeight(140)
+
+        form.addRow("Question", self.question_edit)
+        form.addRow("Context", self.context_edit)
+        form.addRow("Decision", self.decision_edit)
+        form.addRow("Decision rationale", self.rationale_edit)
+
+        layout.addLayout(form)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def values(self) -> tuple[str, str, str, str]:
+        return (
+            self.question_edit.text().strip(),
+            self.context_edit.toPlainText().strip(),
+            self.decision_edit.text().strip(),
+            self.rationale_edit.toPlainText().strip(),
+        )
+
+
 class RecordsTab(QWidget):
     def __init__(
         self,
@@ -95,6 +146,7 @@ class RecordsTab(QWidget):
         columns: Sequence[tuple[str, Callable[[object], object]]],
         load_records: Callable[[], Iterable[object]],
         format_details: Callable[[object], str],
+        details_actions: Sequence[tuple[str, Callable[[], None]]] | None = None,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
@@ -104,6 +156,7 @@ class RecordsTab(QWidget):
         self.format_details = format_details
         self.records: list[object] = []
         self._all_records: list[object] = []
+        self._action_buttons: list[QPushButton] = []
 
         layout = QVBoxLayout(self)
         top_bar = QHBoxLayout()
@@ -115,6 +168,9 @@ class RecordsTab(QWidget):
         self.filter_input.setPlaceholderText("Type to filter…")
         self.filter_input.textChanged.connect(self._apply_filter)
         top_bar.addWidget(self.filter_input)
+        self.clear_filter_button = QPushButton("Clear")
+        self.clear_filter_button.clicked.connect(self._clear_filter)
+        top_bar.addWidget(self.clear_filter_button)
         layout.addLayout(top_bar)
 
         splitter = QSplitter(Qt.Horizontal)
@@ -139,6 +195,17 @@ class RecordsTab(QWidget):
         self.details = QTextEdit()
         self.details.setReadOnly(True)
         details_layout.addWidget(self.details)
+
+        if details_actions:
+            actions_layout = QHBoxLayout()
+            for label, handler in details_actions:
+                button = QPushButton(label)
+                button.clicked.connect(handler)
+                button.setEnabled(False)
+                self._action_buttons.append(button)
+                actions_layout.addWidget(button)
+            actions_layout.addStretch()
+            details_layout.addLayout(actions_layout)
 
         splitter.addWidget(details_panel)
         splitter.setStretchFactor(0, 3)
@@ -170,6 +237,12 @@ class RecordsTab(QWidget):
             return None
         data = asdict(record)
         return str(data.get("id")) if data.get("id") else None
+    
+    def current_records(self) -> list[object]:
+        return list(self.records)
+
+    def current_filter(self) -> str:
+        return self.filter_input.text().strip()
 
     def _on_selection_changed(self) -> None:
         record = self.selected_record()
@@ -178,11 +251,17 @@ class RecordsTab(QWidget):
     def _update_details(self, record: object | None) -> None:
         if record is None:
             self.details.setPlainText("Select a row to see details.")
+            self._set_actions_enabled(False)
             return
         self.details.setPlainText(self.format_details(record))
+        self._set_actions_enabled(True)
+
+    def _set_actions_enabled(self, enabled: bool) -> None:
+        for button in self._action_buttons:
+            button.setEnabled(enabled)
 
     def _apply_filter(self, text: str) -> None:
-        query = text.strip().lower()
+        query = text.strip()
         if query == "":
             self.records = list(self._all_records)
         else:
@@ -190,11 +269,44 @@ class RecordsTab(QWidget):
         self._render_records()
 
     def _matches(self, record: object, query: str) -> bool:
+        tokens = [token for token in query.split() if token]
+        if not tokens:
+            return True
+
+        for token in tokens:
+            if ":" in token:
+                key, value = token.split(":", 1)
+                if not self._match_keyed_token(record, key, value):
+                    return False
+            else:
+                if not self._match_free_token(record, token):
+                    return False
+        return True
+
+    def _match_free_token(self, record: object, token: str) -> bool:
+        needle = token.lower()
         for _, getter in self.columns:
             value = _fmt(getter(record)).lower()
-            if query in value:
+            if needle in value:
                 return True
         return False
+
+    def _match_keyed_token(self, record: object, key: str, value: str) -> bool:
+        key = key.strip().lower()
+        needle = value.strip().lower()
+        if key == "" or needle == "":
+            return False
+
+        column_lookup = {label.lower(): getter for label, getter in self.columns}
+        getter = column_lookup.get(key)
+        if getter is None:
+            return False
+
+        cell = _fmt(getter(record)).lower()
+        return needle in cell
+
+    def _clear_filter(self) -> None:
+        self.filter_input.clear()
 
     def _render_records(self) -> None:
         self.table.setRowCount(len(self.records))
@@ -247,6 +359,10 @@ class MainWindow(QMainWindow):
         self.decide_oq_button.clicked.connect(self.handle_decide_oq)
         actions_layout.addWidget(self.decide_oq_button)
 
+        self.publish_oqs_button = QPushButton("Publish OQs")
+        self.publish_oqs_button.clicked.connect(self.handle_publish_oqs_bulk)
+        actions_layout.addWidget(self.publish_oqs_button)
+
         self.approve_pu_button = QPushButton("Approve PU")
         self.approve_pu_button.clicked.connect(self.handle_approve_pu)
         actions_layout.addWidget(self.approve_pu_button)
@@ -290,6 +406,12 @@ class MainWindow(QMainWindow):
             ],
             load_records=self._load_open_questions,
             format_details=_format_open_question_details,
+            details_actions=[
+                ("Decide OQ", self.handle_decide_oq),
+                ("Modify OQ", self.handle_modify_oq),
+                ("Publish OQ", self.handle_publish_oq),
+                ("Delete OQ", self.handle_delete_oq),
+            ],
         )
         self.tabs.addTab(self.oq_tab, "Open Questions")
 
@@ -373,19 +495,21 @@ class MainWindow(QMainWindow):
         self.refresh_all()
 
     def handle_decide_oq(self) -> None:
-        oq_id = self.oq_tab.selected_id()
-        if not oq_id:
+        record = self.oq_tab.selected_record()
+        if record is None:
             QMessageBox.information(self, "Decide OQ", "Select an OQ first.")
             return
+        oq_id = str(record.id)
 
-        dialog = DecisionDialog(self)
+        dialog = DecisionDialog(
+            self,
+            decision=record.decision or "",
+            rationale=record.decision_rationale or "",
+        )
         if dialog.exec() != QDialog.Accepted:
             return
 
         decision, rationale = dialog.values()
-        if decision == "" or rationale == "":
-            QMessageBox.warning(self, "Decide OQ", "Decision and rationale are required.")
-            return
 
         try:
             use_case = build_add_decision_use_case()
@@ -399,6 +523,197 @@ class MainWindow(QMainWindow):
         else:
             QMessageBox.information(self, "Decide OQ", f"Decision saved for {oq_id}.")
             self.refresh_all()
+
+    def handle_modify_oq(self) -> None:
+        record = self.oq_tab.selected_record()
+        if record is None:
+            QMessageBox.information(self, "Modify OQ", "Select an OQ first.")
+            return
+
+        dialog = EditOQDialog(
+            self,
+            question=record.question or "",
+            context=record.context or "",
+            decision=record.decision or "",
+            rationale=record.decision_rationale or "",
+        )
+        if dialog.exec() != QDialog.Accepted:
+            return
+
+        question, context, decision, rationale = dialog.values()
+        confirm = QMessageBox.question(
+            self,
+            "Confirm OQ update",
+            f"Apply changes to OQ {record.id}?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if confirm != QMessageBox.Yes:
+            return
+
+        try:
+            use_case = build_modify_oq_use_case()
+            result = use_case.execute(
+                record.id,
+                question=question,
+                context=context,
+                decision=decision,
+                decision_rationale=rationale,
+            )
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            QMessageBox.critical(self, "Modify OQ", str(exc))
+            return
+
+        if not result.updated:
+            QMessageBox.warning(self, "Modify OQ", f"OQ {record.id} not found.")
+        else:
+            QMessageBox.information(self, "Modify OQ", f"OQ {record.id} updated.")
+            self.refresh_all()
+
+    def handle_delete_oq(self) -> None:
+        oq_id = self.oq_tab.selected_id()
+        if not oq_id:
+            QMessageBox.information(self, "Delete OQ", "Select an OQ first.")
+            return
+
+        confirm = QMessageBox.question(
+            self,
+            "Confirm delete",
+            "Delete this OQ? Its artifact will be marked IRRELEVANT and linked PUs removed.",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if confirm != QMessageBox.Yes:
+            return
+
+        try:
+            use_case = build_delete_oq_use_case()
+            result = use_case.execute(oq_id)
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            QMessageBox.critical(self, "Delete OQ", str(exc))
+            return
+
+        if not result.deleted:
+            QMessageBox.warning(self, "Delete OQ", f"OQ {oq_id} not found.")
+        else:
+            QMessageBox.information(self, "Delete OQ", f"OQ {oq_id} deleted.")
+            self.refresh_all()
+
+    def handle_publish_oq(self) -> None:
+        record = self.oq_tab.selected_record()
+        if record is None:
+            QMessageBox.information(self, "Publish OQ", "Select an OQ first.")
+            return
+
+        default_channel = os.getenv("SLACK_CHANNEL_ID", "general")
+        channel, ok = QInputDialog.getText(
+            self,
+            "Publish OQ",
+            "Slack channel ID",
+            text=default_channel,
+        )
+        if not ok or channel.strip() == "":
+            return
+
+        confirm = QMessageBox.question(
+            self,
+            "Confirm publish",
+            f"Publish OQ {record.id} to {channel.strip()}?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if confirm != QMessageBox.Yes:
+            return
+
+        try:
+            use_case = build_publish_oqs_use_case()
+            result = use_case.execute([record.id], channel.strip())
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            QMessageBox.critical(self, "Publish OQ", str(exc))
+            return
+
+        message = None
+        if result.missing_ids:
+            message = f"OQ {record.id} not found."
+            QMessageBox.warning(self, "Publish OQ", message)
+        elif result.failed_ids:
+            message = f"Failed to publish OQ {record.id}."
+            QMessageBox.critical(self, "Publish OQ", message)
+        elif result.updated_ids:
+            message = f"Updated published message for {record.id}."
+            QMessageBox.information(self, "Publish OQ", message)
+        elif result.published_ids:
+            message = f"Published OQ {record.id}."
+            QMessageBox.information(self, "Publish OQ", message)
+        elif result.skipped_ids:
+            message = f"OQ {record.id} already published and not modified."
+            QMessageBox.information(self, "Publish OQ", message)
+        else:
+            message = f"No action taken for {record.id}."
+            QMessageBox.information(self, "Publish OQ", message)
+
+        self.refresh_all()
+
+    def handle_publish_oqs_bulk(self) -> None:
+        records = self.oq_tab.current_records()
+        if not records:
+            QMessageBox.information(self, "Publish OQs", "No OQs in the current view.")
+            return
+
+        default_channel = os.getenv("SLACK_CHANNEL_ID", "general")
+        channel, ok = QInputDialog.getText(
+            self,
+            "Publish OQs",
+            "Slack channel ID",
+            text=default_channel,
+        )
+        if not ok or channel.strip() == "":
+            return
+
+        filter_text = self.oq_tab.current_filter()
+        count = len(records)
+        if filter_text:
+            scope_note = f"Filter: {filter_text}"
+        else:
+            scope_note = "No filter applied."
+
+        confirm = QMessageBox.question(
+            self,
+            "Confirm publish",
+            f"Publish {count} OQ(s) to {channel.strip()}?\n{scope_note}",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if confirm != QMessageBox.Yes:
+            return
+
+        oq_ids = [record.id for record in records]
+        try:
+            use_case = build_publish_oqs_use_case()
+            result = use_case.execute(oq_ids, channel.strip())
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            QMessageBox.critical(self, "Publish OQs", str(exc))
+            return
+
+        lines: list[str] = []
+        if result.published_ids:
+            lines.append(f"Published: {len(result.published_ids)}")
+        if result.updated_ids:
+            lines.append(f"Updated: {len(result.updated_ids)}")
+        if result.skipped_ids:
+            lines.append(f"Skipped (not modified): {len(result.skipped_ids)}")
+        if result.missing_ids:
+            lines.append(f"Missing: {len(result.missing_ids)}")
+        if result.failed_ids:
+            lines.append(f"Failed: {len(result.failed_ids)}")
+
+        message = "\n".join(lines) if lines else "No action taken."
+        if result.failed_ids:
+            QMessageBox.warning(self, "Publish OQs", message)
+        else:
+            QMessageBox.information(self, "Publish OQs", message)
+
+        self.refresh_all()
 
     def handle_approve_pu(self) -> None:
         pu_id = self.pu_tab.selected_id()

--- a/src/use_cases/add_decision.py
+++ b/src/use_cases/add_decision.py
@@ -25,7 +25,11 @@ class AddDecisionUseCase:
         oq.decision = decision
         oq.decision_rationale = rationale
         if self._has_decision(oq):
-            oq.status = "DECIDED"
+            if oq.status in {"OPEN", "DECIDED"}:
+                oq.status = "DECIDED"
+        else:
+            if oq.status == "DECIDED":
+                oq.status = "OPEN"
         self.oq_repo.save(oq)
         return AddDecisionResult(updated=True, oq=oq)
 

--- a/src/use_cases/build_decision_from_thread.py
+++ b/src/use_cases/build_decision_from_thread.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from src.domain.models import OpenQuestion
+from src.ports.llm import LLMDecisionPort
+from src.ports.repositories import OpenQuestionRepository
+from src.ports.slack import SlackThreadsPort
+
+Normalizer = Callable[[dict], str]
+
+
+@dataclass
+class BuildDecisionFromThreadResult:
+    updated: bool
+    oq: OpenQuestion | None
+    decision: str | None
+    decision_rationale: str | None
+    reason: str | None
+    messages_used: int = 0
+
+
+class BuildDecisionFromThreadUseCase:
+    # Builds a decision from the published OQ's Slack thread replies.
+    def __init__(
+        self,
+        oq_repo: OpenQuestionRepository,
+        slack_port: SlackThreadsPort,
+        llm_decider: LLMDecisionPort,
+        normalizer: Normalizer,
+        tech_team_user_ids: set[str] | None = None,
+    ) -> None:
+        self.oq_repo = oq_repo
+        self.slack_port = slack_port
+        self.llm_decider = llm_decider
+        self.normalizer = normalizer
+        self.tech_team_user_ids = tech_team_user_ids or set()
+
+    def execute(self, oq_id: str) -> BuildDecisionFromThreadResult:
+        oq = self.oq_repo.get_by_id(oq_id)
+        if not oq:
+            return BuildDecisionFromThreadResult(
+                updated=False,
+                oq=None,
+                decision=None,
+                decision_rationale=None,
+                reason="missing_oq",
+            )
+
+        channel_id = oq.published_channel_id
+        thread_ts = oq.published_message_ts
+        if not channel_id or not thread_ts:
+            return BuildDecisionFromThreadResult(
+                updated=False,
+                oq=oq,
+                decision=None,
+                decision_rationale=None,
+                reason="not_published",
+            )
+
+        thread = self.slack_port.fetch_thread(channel_id, thread_ts)
+        if not thread or not thread.get("messages"):
+            return BuildDecisionFromThreadResult(
+                updated=False,
+                oq=oq,
+                decision=None,
+                decision_rationale=None,
+                reason="thread_missing",
+            )
+
+        messages = thread.get("messages", [])
+        tech_messages = [msg for msg in messages if self._is_tech_reply(msg, thread_ts)]
+        if not tech_messages:
+            return BuildDecisionFromThreadResult(
+                updated=False,
+                oq=oq,
+                decision=None,
+                decision_rationale=None,
+                reason="no_tech_messages",
+            )
+
+        convo_text = self.normalizer({"messages": tech_messages})
+        decision_payload = self.llm_decider.decide(oq.question, oq.context, convo_text)
+        if not decision_payload:
+            return BuildDecisionFromThreadResult(
+                updated=False,
+                oq=oq,
+                decision=None,
+                decision_rationale=None,
+                reason="llm_failed",
+            )
+
+        decision = str(decision_payload.get("decision", "")).strip()
+        rationale = str(
+            decision_payload.get("decision_rationale", decision_payload.get("rationale", ""))
+        ).strip()
+        if not decision or not rationale:
+            return BuildDecisionFromThreadResult(
+                updated=False,
+                oq=oq,
+                decision=decision or None,
+                decision_rationale=rationale or None,
+                reason="empty_decision",
+            )
+
+        self._apply_decision(oq, decision, rationale)
+        self.oq_repo.save(oq)
+
+        return BuildDecisionFromThreadResult(
+            updated=True,
+            oq=oq,
+            decision=decision,
+            decision_rationale=rationale,
+            reason=None,
+            messages_used=len(tech_messages),
+        )
+
+    def _is_tech_reply(self, msg: dict, thread_ts: str) -> bool:
+        if msg.get("ts") == thread_ts:
+            return False
+        if msg.get("bot_id") or msg.get("subtype") == "bot_message":
+            return False
+        user = msg.get("user")
+        if not user:
+            return False
+        if self.tech_team_user_ids and user not in self.tech_team_user_ids:
+            return False
+        text = msg.get("text", "").strip()
+        if not text:
+            return False
+        return True
+
+    def _apply_decision(self, oq: OpenQuestion, decision: str, rationale: str) -> None:
+        oq.decision = decision
+        oq.decision_rationale = rationale
+        if self._has_decision(oq):
+            if oq.status == "PUBLISHED":
+                oq.status = "READY_TO_TRANSFORM"
+            elif oq.status in {"OPEN", "DECIDED"}:
+                oq.status = "DECIDED"
+        else:
+            if oq.status == "DECIDED":
+                oq.status = "OPEN"
+
+    def _has_decision(self, oq: OpenQuestion) -> bool:
+        if not oq.decision or not oq.decision_rationale:
+            return False
+        if str(oq.decision).strip() == "" or str(oq.decision_rationale).strip() == "":
+            return False
+        return True

--- a/src/use_cases/delete_oq.py
+++ b/src/use_cases/delete_oq.py
@@ -38,3 +38,44 @@ class DeleteOQUseCase:
             self.artifact_repo.save(artifact)
 
         return DeleteOQResult(deleted=True, oq_id=oq_id, artifact_id=oq.artifact_id)
+
+
+@dataclass
+class DeleteOQBatchResult:
+    deleted_ids: list[str]
+    missing_ids: list[str]
+
+
+class DeleteOQBatchUseCase:
+    # Deletes multiple OQs, marks their artifacts IRRELEVANT, and deletes linked PUs.
+    def __init__(
+        self,
+        oq_repo: OpenQuestionRepository,
+        artifact_repo: ArtifactRepository,
+        pu_repo: ProposedUpdateRepository,
+    ) -> None:
+        self.oq_repo = oq_repo
+        self.artifact_repo = artifact_repo
+        self.pu_repo = pu_repo
+
+    def execute(self, oq_ids: list[str]) -> DeleteOQBatchResult:
+        deleted_ids: list[str] = []
+        missing_ids: list[str] = []
+
+        for oq_id in oq_ids:
+            oq = self.oq_repo.get_by_id(oq_id)
+            if not oq:
+                missing_ids.append(oq_id)
+                continue
+
+            self.oq_repo.delete_by_id(oq_id)
+            self.pu_repo.delete_by_source_oq_id(oq_id)
+
+            artifact = self.artifact_repo.get_by_id(oq.artifact_id)
+            if artifact:
+                artifact.status = "IRRELEVANT"
+                self.artifact_repo.save(artifact)
+
+            deleted_ids.append(oq_id)
+
+        return DeleteOQBatchResult(deleted_ids=deleted_ids, missing_ids=missing_ids)

--- a/src/use_cases/delete_oq.py
+++ b/src/use_cases/delete_oq.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.ports.repositories import ArtifactRepository, OpenQuestionRepository, ProposedUpdateRepository
+
+
+@dataclass
+class DeleteOQResult:
+    deleted: bool
+    oq_id: str
+    artifact_id: str | None
+
+
+class DeleteOQUseCase:
+    # Deletes an OQ, marks its artifact IRRELEVANT, and deletes linked PUs.
+    def __init__(
+        self,
+        oq_repo: OpenQuestionRepository,
+        artifact_repo: ArtifactRepository,
+        pu_repo: ProposedUpdateRepository,
+    ) -> None:
+        self.oq_repo = oq_repo
+        self.artifact_repo = artifact_repo
+        self.pu_repo = pu_repo
+
+    def execute(self, oq_id: str) -> DeleteOQResult:
+        oq = self.oq_repo.get_by_id(oq_id)
+        if not oq:
+            return DeleteOQResult(deleted=False, oq_id=oq_id, artifact_id=None)
+
+        self.oq_repo.delete_by_id(oq_id)
+        self.pu_repo.delete_by_source_oq_id(oq_id)
+
+        artifact = self.artifact_repo.get_by_id(oq.artifact_id)
+        if artifact:
+            artifact.status = "IRRELEVANT"
+            self.artifact_repo.save(artifact)
+
+        return DeleteOQResult(deleted=True, oq_id=oq_id, artifact_id=oq.artifact_id)

--- a/src/use_cases/ingest.py
+++ b/src/use_cases/ingest.py
@@ -16,6 +16,9 @@ Normalizer = Callable[[dict], str]
 class IngestResult:
     threads_fetched: int
     artifacts_created: int
+    oq_count: int
+    pu_count: int
+    irrelevant_count: int
 
 
 class IngestUseCase:
@@ -41,7 +44,13 @@ class IngestUseCase:
     ) -> IngestResult:
         threads = self.slack_port.fetch_threads(channel_id)
         if not threads:
-            return IngestResult(threads_fetched=0, artifacts_created=0)
+            return IngestResult(
+                threads_fetched=0,
+                artifacts_created=0,
+                oq_count=0,
+                pu_count=0,
+                irrelevant_count=0,
+            )
 
         if on_start_run:
             on_start_run()
@@ -60,4 +69,7 @@ class IngestUseCase:
         return IngestResult(
             threads_fetched=len(threads),
             artifacts_created=result.artifacts_created,
+            oq_count=result.oq_count,
+            pu_count=result.pu_count,
+            irrelevant_count=result.irrelevant_count,
         )

--- a/src/use_cases/ingest_threads.py
+++ b/src/use_cases/ingest_threads.py
@@ -15,6 +15,9 @@ Normalizer = Callable[[dict], str]
 class IngestThreadsResult:
     conversations: list[dict]
     artifacts_created: int
+    oq_count: int
+    pu_count: int
+    irrelevant_count: int
 
 
 class IngestThreadsUseCase:
@@ -35,6 +38,9 @@ class IngestThreadsUseCase:
 
         conversations: list[dict] = []
         artifacts_created = 0
+        oq_count = 0
+        pu_count = 0
+        irrelevant_count = 0
 
         for thread in threads:
             ts = thread.get("ts")
@@ -52,16 +58,23 @@ class IngestThreadsUseCase:
                 continue
 
             artifact_type = self._parse_artifact_type(classification.get("type"))
-            if artifact_type == ArtifactType.IRRELEVANT:
-                continue
-
-            artifact = self._artifact_from_classification(ts, artifact_type, classification)
+            artifact_status = "IRRELEVANT" if artifact_type == ArtifactType.IRRELEVANT else "PENDING"
+            artifact = self._artifact_from_classification(ts, artifact_type, classification, status=artifact_status)
             self.artifact_repo.save(artifact)
             artifacts_created += 1
+            if artifact_type == ArtifactType.OQ:
+                oq_count += 1
+            elif artifact_type == ArtifactType.PU:
+                pu_count += 1
+            else:
+                irrelevant_count += 1
 
         return IngestThreadsResult(
             conversations=conversations,
             artifacts_created=artifacts_created,
+            oq_count=oq_count,
+            pu_count=pu_count,
+            irrelevant_count=irrelevant_count,
         )
 
     def _parse_artifact_type(self, raw_type: object) -> ArtifactType:
@@ -77,12 +90,13 @@ class IngestThreadsUseCase:
         conversation_id: str,
         artifact_type: ArtifactType,
         classification: dict,
+        status: str = "PENDING",
     ) -> Artifact:
         return Artifact(
             id=f"art_{uuid.uuid4().hex[:8]}",
             conversation_id=conversation_id,
             type=artifact_type,
-            status="PENDING",
+            status=status,
             rephrasing=classification.get("rephrasing", ""),
             rationale=classification.get("rationale", ""),
             summary_of_context=classification.get("summary_of_context", ""),

--- a/src/use_cases/ingest_threads.py
+++ b/src/use_cases/ingest_threads.py
@@ -46,6 +46,8 @@ class IngestThreadsUseCase:
             ts = thread.get("ts")
             if not ts:
                 continue
+            channel_id = thread.get("channel_id")
+            thread_url = thread.get("thread_url") or thread.get("permalink")
 
             conv_text = self.normalizer(thread)
             conversations.append({"ts": ts, "text": conv_text})
@@ -59,7 +61,15 @@ class IngestThreadsUseCase:
 
             artifact_type = self._parse_artifact_type(classification.get("type"))
             artifact_status = "IRRELEVANT" if artifact_type == ArtifactType.IRRELEVANT else "PENDING"
-            artifact = self._artifact_from_classification(ts, artifact_type, classification, status=artifact_status)
+            artifact = self._artifact_from_classification(
+                ts,
+                artifact_type,
+                classification,
+                status=artifact_status,
+                source_channel_id=channel_id,
+                source_thread_ts=ts,
+                source_thread_url=thread_url,
+            )
             self.artifact_repo.save(artifact)
             artifacts_created += 1
             if artifact_type == ArtifactType.OQ:
@@ -91,6 +101,9 @@ class IngestThreadsUseCase:
         artifact_type: ArtifactType,
         classification: dict,
         status: str = "PENDING",
+        source_channel_id: str | None = None,
+        source_thread_ts: str | None = None,
+        source_thread_url: str | None = None,
     ) -> Artifact:
         return Artifact(
             id=f"art_{uuid.uuid4().hex[:8]}",
@@ -100,4 +113,7 @@ class IngestThreadsUseCase:
             rephrasing=classification.get("rephrasing", ""),
             rationale=classification.get("rationale", ""),
             summary_of_context=classification.get("summary_of_context", ""),
+            source_channel_id=source_channel_id,
+            source_thread_ts=source_thread_ts,
+            source_thread_url=source_thread_url,
         )

--- a/src/use_cases/list_all_oq.py
+++ b/src/use_cases/list_all_oq.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from src.domain.models import OpenQuestion
+from src.ports.repositories import OpenQuestionRepository
+
+
+class ListAllOQUseCase:
+    # Returns all open-question records from the repository, regardless of status.
+    def __init__(self, oq_repo: OpenQuestionRepository) -> None:
+        self.oq_repo = oq_repo
+
+    def execute(self) -> list[OpenQuestion]:
+        return list(self.oq_repo.list_all())

--- a/src/use_cases/list_open_questions.py
+++ b/src/use_cases/list_open_questions.py
@@ -5,9 +5,9 @@ from src.ports.repositories import OpenQuestionRepository
 
 
 class ListOpenQuestionsUseCase:
-    # Returns all open questions from the repository.
+    # Returns only open questions from the repository.
     def __init__(self, oq_repo: OpenQuestionRepository) -> None:
         self.oq_repo = oq_repo
 
     def execute(self) -> list[OpenQuestion]:
-        return list(self.oq_repo.list_all())
+        return [oq for oq in self.oq_repo.list_all() if oq.status == "OPEN"]

--- a/src/use_cases/modify_oq.py
+++ b/src/use_cases/modify_oq.py
@@ -32,6 +32,7 @@ class ModifyOQUseCase:
             return ModifyOQResult(updated=False, oq=None)
 
         was_decided = oq.status == "DECIDED"
+        was_transformed = oq.status == "TRANSFORMED"
 
         if question is not None:
             oq.question = question
@@ -42,13 +43,18 @@ class ModifyOQUseCase:
         if decision_rationale is not None:
             oq.decision_rationale = decision_rationale
 
-        oq.status = "OPEN"
+        oq.status = "DECIDED" if self._has_decision(oq) else "OPEN"
         oq.last_modified_at = datetime.datetime.now().isoformat()
         self.oq_repo.save(oq)
 
-        if was_decided:
+        if was_decided or was_transformed:
             self.pu_repo.delete_by_source_oq_id(oq.id)
 
         return ModifyOQResult(updated=True, oq=oq)
 
-    # No helper methods needed beyond modification logic.
+    def _has_decision(self, oq: OpenQuestion) -> bool:
+        if not oq.decision or not oq.decision_rationale:
+            return False
+        if str(oq.decision).strip() == "" or str(oq.decision_rationale).strip() == "":
+            return False
+        return True

--- a/src/use_cases/modify_oq.py
+++ b/src/use_cases/modify_oq.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import uuid
+import datetime
 from dataclasses import dataclass
 
-from src.domain.models import OpenQuestion, ProposedUpdate
+from src.domain.models import OpenQuestion
 from src.ports.repositories import OpenQuestionRepository, ProposedUpdateRepository
 
 
@@ -42,33 +42,13 @@ class ModifyOQUseCase:
         if decision_rationale is not None:
             oq.decision_rationale = decision_rationale
 
-        oq.status = "DECIDED" if self._has_decision(oq) else "OPEN"
+        oq.status = "OPEN"
+        oq.last_modified_at = datetime.datetime.now().isoformat()
         self.oq_repo.save(oq)
 
-        if oq.status == "DECIDED":
-            self.pu_repo.delete_by_source_oq_id(oq.id)
-            pu = self._create_pu_from_oq(oq)
-            self.pu_repo.save(pu)
-        elif was_decided:
+        if was_decided:
             self.pu_repo.delete_by_source_oq_id(oq.id)
 
         return ModifyOQResult(updated=True, oq=oq)
 
-    def _has_decision(self, oq: OpenQuestion) -> bool:
-        if not oq.decision or not oq.decision_rationale:
-            return False
-        if str(oq.decision).strip() == "" or str(oq.decision_rationale).strip() == "":
-            return False
-        return True
-
-    def _create_pu_from_oq(self, oq: OpenQuestion) -> ProposedUpdate:
-        return ProposedUpdate(
-            id=f"pu_from_oq_{uuid.uuid4().hex[:8]}",
-            artifact_id=oq.artifact_id,
-            source_oq_id=oq.id,
-            rephrasing=oq.question,
-            context=oq.context,
-            decision=oq.decision or "",
-            rationale=oq.decision_rationale or "Transformed from OQ",
-            status="DRAFT",
-        )
+    # No helper methods needed beyond modification logic.

--- a/src/use_cases/publish_oq.py
+++ b/src/use_cases/publish_oq.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+
+from src.domain.models import OpenQuestion
+from src.ports.repositories import OpenQuestionRepository
+from src.ports.slack_publish import SlackPublishPort
+
+
+@dataclass
+class PublishOQsResult:
+    published_ids: list[str]
+    updated_ids: list[str]
+    skipped_ids: list[str]
+    missing_ids: list[str]
+    failed_ids: list[str]
+
+
+class PublishOQsUseCase:
+    # Publishes OQs to Slack; republishes only if modified since last publish.
+    def __init__(self, oq_repo: OpenQuestionRepository, slack_publish: SlackPublishPort) -> None:
+        self.oq_repo = oq_repo
+        self.slack_publish = slack_publish
+
+    def execute(self, oq_ids: list[str], channel_id: str) -> PublishOQsResult:
+        published_ids: list[str] = []
+        updated_ids: list[str] = []
+        skipped_ids: list[str] = []
+        missing_ids: list[str] = []
+        failed_ids: list[str] = []
+
+        for oq_id in oq_ids:
+            oq = self.oq_repo.get_by_id(oq_id)
+            if not oq:
+                missing_ids.append(oq_id)
+                continue
+
+            message = self._build_message(oq)
+            try:
+                if oq.published_at:
+                    if self._should_republish(oq):
+                        if oq.published_message_ts:
+                            ts = self.slack_publish.update_message(channel_id, oq.published_message_ts, message)
+                            self._mark_published(oq, channel_id, ts)
+                            updated_ids.append(oq_id)
+                        else:
+                            ts = self.slack_publish.post_message(channel_id, message)
+                            self._mark_published(oq, channel_id, ts)
+                            published_ids.append(oq_id)
+                    else:
+                        skipped_ids.append(oq_id)
+                else:
+                    ts = self.slack_publish.post_message(channel_id, message)
+                    self._mark_published(oq, channel_id, ts)
+                    published_ids.append(oq_id)
+            except Exception:
+                failed_ids.append(oq_id)
+                continue
+
+        return PublishOQsResult(
+            published_ids=published_ids,
+            updated_ids=updated_ids,
+            skipped_ids=skipped_ids,
+            missing_ids=missing_ids,
+            failed_ids=failed_ids,
+        )
+
+    def _build_message(self, oq: OpenQuestion) -> str:
+        return (
+            f"Open Question:\n{oq.question}\n\n"
+            f"Context:\n{oq.context}\n\n"
+            "Please reply in this thread."
+        )
+
+    def _mark_published(self, oq: OpenQuestion, channel_id: str, message_ts: str) -> None:
+        oq.status = "PUBLISHED"
+        oq.published_at = datetime.datetime.now().isoformat()
+        oq.published_message_ts = message_ts
+        oq.published_channel_id = channel_id
+        self.oq_repo.save(oq)
+
+    def _should_republish(self, oq: OpenQuestion) -> bool:
+        if not oq.last_modified_at or not oq.published_at:
+            return False
+        try:
+            modified = datetime.datetime.fromisoformat(oq.last_modified_at)
+            published = datetime.datetime.fromisoformat(oq.published_at)
+        except Exception:
+            return True
+        return modified > published

--- a/src/use_cases/publish_oq.py
+++ b/src/use_cases/publish_oq.py
@@ -35,6 +35,9 @@ class PublishOQsUseCase:
             if not oq:
                 missing_ids.append(oq_id)
                 continue
+            if oq.status != "OPEN":
+                skipped_ids.append(oq_id)
+                continue
 
             message = self._build_message(oq)
             try:

--- a/src/use_cases/reset_data.py
+++ b/src/use_cases/reset_data.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.ports.data_reset import DataResetPort
+
+
+@dataclass
+class ResetDataResult:
+    success: bool
+
+
+class ResetDataUseCase:
+    # Clears all stored JSON data (artifacts, OQs, PUs, threads, conversations).
+    def __init__(self, reset_port: DataResetPort) -> None:
+        self.reset_port = reset_port
+
+    def execute(self) -> ResetDataResult:
+        self.reset_port.reset_all()
+        return ResetDataResult(success=True)

--- a/src/use_cases/set_last_ts.py
+++ b/src/use_cases/set_last_ts.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from src.ports.sources_state import SourcesStatePort
+
+
+@dataclass
+class SetLastTsResult:
+    channel_id: str
+    last_ts: str
+
+
+class SetLastTsUseCase:
+    # Sets last_ts based on a number of days back from now.
+    def __init__(self, sources_state: SourcesStatePort) -> None:
+        self.sources_state = sources_state
+
+    def execute(self, channel_id: str, days_back: float, now_ts: float | None = None) -> SetLastTsResult:
+        if now_ts is None:
+            now_ts = time.time()
+        last_ts_value = now_ts - (days_back * 86400)
+        last_ts = f"{last_ts_value:.6f}"
+        self.sources_state.set_last_ts(channel_id, last_ts)
+        return SetLastTsResult(channel_id=channel_id, last_ts=last_ts)

--- a/src/use_cases/transform_oq.py
+++ b/src/use_cases/transform_oq.py
@@ -27,7 +27,7 @@ class TransformOQUseCase:
         transformed = 0
 
         for oq in self.oq_repo.list_all():
-            if oq.status not in {"OPEN", "DECIDED"}:
+            if oq.status not in {"OPEN", "DECIDED", "READY_TO_TRANSFORM"}:
                 continue
             if not self._has_decision(oq):
                 continue
@@ -55,6 +55,9 @@ class TransformOQUseCase:
             decision=oq.decision or "",
             rationale=oq.decision_rationale or "Transformed from OQ",
             status="DRAFT",
+            source_channel_id=oq.source_channel_id,
+            source_thread_ts=oq.source_thread_ts,
+            source_thread_url=oq.source_thread_url,
         )
 
     def _has_decision(self, oq: OpenQuestion) -> bool:

--- a/tests/test_add_decision.py
+++ b/tests/test_add_decision.py
@@ -79,6 +79,27 @@ class AddDecisionUseCaseTests(unittest.TestCase):
         self.assertIsNotNone(result.oq)
         self.assertEqual(result.oq.status, "OPEN")
 
+    def test_incomplete_decision_resets_decided_to_open(self):
+        oq = OpenQuestion(
+            id="oq_3",
+            artifact_id="art_3",
+            question="Q3",
+            context="ctx",
+            status="DECIDED",
+            slack_ts=None,
+            decision="DECISION",
+            decision_rationale="WHY",
+        )
+
+        oq_repo = FakeOQRepo([oq])
+        use_case = AddDecisionUseCase(oq_repo)
+
+        result = use_case.execute("oq_3", decision="DECISION", rationale="")
+
+        self.assertTrue(result.updated)
+        self.assertIsNotNone(result.oq)
+        self.assertEqual(result.oq.status, "OPEN")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_build_decision_from_thread.py
+++ b/tests/test_build_decision_from_thread.py
@@ -1,0 +1,291 @@
+import unittest
+
+from src.domain.models import OpenQuestion
+from src.use_cases.build_decision_from_thread import BuildDecisionFromThreadUseCase
+
+
+class FakeOQRepo:
+    def __init__(self, questions):
+        self._questions = {q.id: q for q in questions}
+        self.saved = []
+
+    def list_all(self):
+        return list(self._questions.values())
+
+    def get_by_id(self, oq_id: str):
+        return self._questions.get(oq_id)
+
+    def save(self, oq: OpenQuestion):
+        self._questions[oq.id] = oq
+        self.saved.append(oq)
+
+    def create_from_artifact(self, artifact):
+        raise NotImplementedError("Not needed for this test")
+
+
+class FakeSlackPort:
+    def __init__(self, thread):
+        self.thread = thread
+        self.calls = []
+
+    def fetch_thread(self, channel_id: str, thread_ts: str):
+        self.calls.append((channel_id, thread_ts))
+        return self.thread
+
+    def fetch_threads(self, channel_id: str):
+        raise NotImplementedError("Not needed for this test")
+
+
+class FakeLLMDecision:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = []
+
+    def decide(self, question: str, context: str, thread_text: str):
+        self.calls.append((question, context, thread_text))
+        return self.payload
+
+
+class RecordingNormalizer:
+    def __init__(self, text="normalized"):
+        self.text = text
+        self.calls = []
+
+    def __call__(self, thread: dict) -> str:
+        self.calls.append(thread)
+        return self.text
+
+
+class BuildDecisionFromThreadUseCaseTests(unittest.TestCase):
+    def test_missing_oq_returns_reason(self):
+        repo = FakeOQRepo([])
+        use_case = BuildDecisionFromThreadUseCase(
+            repo,
+            FakeSlackPort(thread=None),
+            FakeLLMDecision(payload={"decision": "X", "decision_rationale": "Y"}),
+            RecordingNormalizer(),
+        )
+
+        result = use_case.execute("missing")
+
+        self.assertFalse(result.updated)
+        self.assertEqual(result.reason, "missing_oq")
+
+    def test_not_published_returns_reason(self):
+        oq = OpenQuestion(
+            id="oq_1",
+            artifact_id="art_1",
+            question="Q1",
+            context="ctx",
+            status="OPEN",
+            slack_ts=None,
+            decision=None,
+            decision_rationale=None,
+            published_channel_id=None,
+            published_message_ts=None,
+        )
+
+        repo = FakeOQRepo([oq])
+        use_case = BuildDecisionFromThreadUseCase(
+            repo,
+            FakeSlackPort(thread=None),
+            FakeLLMDecision(payload={"decision": "X", "decision_rationale": "Y"}),
+            RecordingNormalizer(),
+        )
+
+        result = use_case.execute("oq_1")
+
+        self.assertFalse(result.updated)
+        self.assertEqual(result.reason, "not_published")
+
+    def test_thread_missing_returns_reason(self):
+        oq = OpenQuestion(
+            id="oq_2",
+            artifact_id="art_2",
+            question="Q2",
+            context="ctx",
+            status="OPEN",
+            slack_ts=None,
+            decision=None,
+            decision_rationale=None,
+            published_channel_id="C1",
+            published_message_ts="123.45",
+        )
+
+        repo = FakeOQRepo([oq])
+        use_case = BuildDecisionFromThreadUseCase(
+            repo,
+            FakeSlackPort(thread=None),
+            FakeLLMDecision(payload={"decision": "X", "decision_rationale": "Y"}),
+            RecordingNormalizer(),
+        )
+
+        result = use_case.execute("oq_2")
+
+        self.assertFalse(result.updated)
+        self.assertEqual(result.reason, "thread_missing")
+
+    def test_no_tech_messages_returns_reason(self):
+        thread_ts = "1700000000.0001"
+        thread = {
+            "ts": thread_ts,
+            "messages": [
+                {"ts": thread_ts, "user": "U1", "text": "Root message"},
+                {"ts": "1700000000.0002", "user": "U2", "text": "Reply"},
+            ],
+        }
+
+        oq = OpenQuestion(
+            id="oq_3",
+            artifact_id="art_3",
+            question="Q3",
+            context="ctx",
+            status="OPEN",
+            slack_ts=None,
+            decision=None,
+            decision_rationale=None,
+            published_channel_id="C1",
+            published_message_ts=thread_ts,
+        )
+
+        repo = FakeOQRepo([oq])
+        use_case = BuildDecisionFromThreadUseCase(
+            repo,
+            FakeSlackPort(thread=thread),
+            FakeLLMDecision(payload={"decision": "X", "decision_rationale": "Y"}),
+            RecordingNormalizer(),
+            tech_team_user_ids={"U1"},
+        )
+
+        result = use_case.execute("oq_3")
+
+        self.assertFalse(result.updated)
+        self.assertEqual(result.reason, "no_tech_messages")
+
+    def test_llm_failed_returns_reason(self):
+        thread_ts = "1700000000.0001"
+        thread = {
+            "ts": thread_ts,
+            "messages": [
+                {"ts": thread_ts, "user": "U1", "text": "Root message"},
+                {"ts": "1700000000.0002", "user": "U1", "text": "Reply"},
+            ],
+        }
+
+        oq = OpenQuestion(
+            id="oq_4",
+            artifact_id="art_4",
+            question="Q4",
+            context="ctx",
+            status="OPEN",
+            slack_ts=None,
+            decision=None,
+            decision_rationale=None,
+            published_channel_id="C1",
+            published_message_ts=thread_ts,
+        )
+
+        repo = FakeOQRepo([oq])
+        use_case = BuildDecisionFromThreadUseCase(
+            repo,
+            FakeSlackPort(thread=thread),
+            FakeLLMDecision(payload=None),
+            RecordingNormalizer(),
+        )
+
+        result = use_case.execute("oq_4")
+
+        self.assertFalse(result.updated)
+        self.assertEqual(result.reason, "llm_failed")
+
+    def test_empty_decision_returns_reason(self):
+        thread_ts = "1700000000.0001"
+        thread = {
+            "ts": thread_ts,
+            "messages": [
+                {"ts": thread_ts, "user": "U1", "text": "Root message"},
+                {"ts": "1700000000.0002", "user": "U1", "text": "Reply"},
+            ],
+        }
+
+        oq = OpenQuestion(
+            id="oq_5",
+            artifact_id="art_5",
+            question="Q5",
+            context="ctx",
+            status="OPEN",
+            slack_ts=None,
+            decision=None,
+            decision_rationale=None,
+            published_channel_id="C1",
+            published_message_ts=thread_ts,
+        )
+
+        repo = FakeOQRepo([oq])
+        use_case = BuildDecisionFromThreadUseCase(
+            repo,
+            FakeSlackPort(thread=thread),
+            FakeLLMDecision(payload={"decision": " ", "decision_rationale": "Rationale"}),
+            RecordingNormalizer(),
+        )
+
+        result = use_case.execute("oq_5")
+
+        self.assertFalse(result.updated)
+        self.assertEqual(result.reason, "empty_decision")
+
+    def test_success_updates_oq_and_filters_messages(self):
+        thread_ts = "1700000000.0001"
+        messages = [
+            {"ts": thread_ts, "user": "U1", "text": "Root message"},
+            {"ts": "1700000000.0002", "user": "U1", "text": "We should do X"},
+            {"ts": "1700000000.0003", "user": "U2", "text": "Agree"},
+            {"ts": "1700000000.0004", "user": "U3", "text": ""},
+        ]
+        thread = {"ts": thread_ts, "messages": messages}
+
+        oq = OpenQuestion(
+            id="oq_6",
+            artifact_id="art_6",
+            question="Q6",
+            context="ctx",
+            status="PUBLISHED",
+            slack_ts=None,
+            decision=None,
+            decision_rationale=None,
+            published_channel_id="C1",
+            published_message_ts=thread_ts,
+        )
+
+        normalizer = RecordingNormalizer(text="normalized thread")
+        repo = FakeOQRepo([oq])
+        use_case = BuildDecisionFromThreadUseCase(
+            repo,
+            FakeSlackPort(thread=thread),
+            FakeLLMDecision(payload={"decision": "Do X", "decision_rationale": "Team agreed"}),
+            normalizer,
+            tech_team_user_ids={"U1", "U2"},
+        )
+
+        result = use_case.execute("oq_6")
+
+        self.assertTrue(result.updated)
+        self.assertIsNone(result.reason)
+        self.assertEqual(result.decision, "Do X")
+        self.assertEqual(result.decision_rationale, "Team agreed")
+        self.assertEqual(result.messages_used, 2)
+        self.assertEqual(repo.get_by_id("oq_6").decision, "Do X")
+        self.assertEqual(repo.get_by_id("oq_6").decision_rationale, "Team agreed")
+        self.assertEqual(repo.get_by_id("oq_6").status, "READY_TO_TRANSFORM")
+        self.assertEqual(len(normalizer.calls), 1)
+        self.assertEqual(
+            normalizer.calls[0]["messages"],
+            [
+                {"ts": "1700000000.0002", "user": "U1", "text": "We should do X"},
+                {"ts": "1700000000.0003", "user": "U2", "text": "Agree"},
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_delete_oq.py
+++ b/tests/test_delete_oq.py
@@ -1,7 +1,7 @@
 import unittest
 
 from src.domain.models import Artifact, ArtifactType, OpenQuestion, ProposedUpdate
-from src.use_cases.delete_oq import DeleteOQUseCase
+from src.use_cases.delete_oq import DeleteOQUseCase, DeleteOQBatchUseCase
 
 
 class FakeArtifactRepo:
@@ -123,6 +123,61 @@ class DeleteOQUseCaseTests(unittest.TestCase):
 
         self.assertFalse(result.deleted)
         self.assertIsNone(result.artifact_id)
+
+
+class DeleteOQBatchUseCaseTests(unittest.TestCase):
+    # Verifies that batch delete handles deleted and missing IDs.
+    def test_batch_delete(self):
+        artifact1 = Artifact(
+            id="art_1",
+            conversation_id="c1",
+            type=ArtifactType.OQ,
+            status="PENDING",
+            rephrasing="",
+            rationale="",
+            summary_of_context="",
+        )
+        artifact2 = Artifact(
+            id="art_2",
+            conversation_id="c2",
+            type=ArtifactType.OQ,
+            status="PENDING",
+            rephrasing="",
+            rationale="",
+            summary_of_context="",
+        )
+        oq1 = OpenQuestion(
+            id="oq_1",
+            artifact_id="art_1",
+            question="Q1",
+            context="ctx",
+            status="OPEN",
+            slack_ts=None,
+            decision=None,
+            decision_rationale=None,
+        )
+        oq2 = OpenQuestion(
+            id="oq_2",
+            artifact_id="art_2",
+            question="Q2",
+            context="ctx",
+            status="OPEN",
+            slack_ts=None,
+            decision=None,
+            decision_rationale=None,
+        )
+
+        oq_repo = FakeOQRepo([oq1, oq2])
+        artifact_repo = FakeArtifactRepo([artifact1, artifact2])
+        pu_repo = FakePURepo([])
+
+        use_case = DeleteOQBatchUseCase(oq_repo, artifact_repo, pu_repo)
+        result = use_case.execute(["oq_1", "missing", "oq_2"])
+
+        self.assertEqual(set(result.deleted_ids), {"oq_1", "oq_2"})
+        self.assertEqual(result.missing_ids, ["missing"])
+        self.assertEqual(artifact_repo.get_by_id("art_1").status, "IRRELEVANT")
+        self.assertEqual(artifact_repo.get_by_id("art_2").status, "IRRELEVANT")
 
 
 if __name__ == "__main__":

--- a/tests/test_delete_oq.py
+++ b/tests/test_delete_oq.py
@@ -1,0 +1,129 @@
+import unittest
+
+from src.domain.models import Artifact, ArtifactType, OpenQuestion, ProposedUpdate
+from src.use_cases.delete_oq import DeleteOQUseCase
+
+
+class FakeArtifactRepo:
+    def __init__(self, artifacts):
+        self._artifacts = {a.id: a for a in artifacts}
+        self.saved = []
+
+    def list_all(self):
+        return list(self._artifacts.values())
+
+    def get_by_id(self, artifact_id: str):
+        return self._artifacts.get(artifact_id)
+
+    def save(self, artifact: Artifact):
+        self._artifacts[artifact.id] = artifact
+        self.saved.append(artifact)
+
+
+class FakeOQRepo:
+    def __init__(self, questions):
+        self._questions = {q.id: q for q in questions}
+        self.deleted_ids = []
+
+    def list_all(self):
+        return list(self._questions.values())
+
+    def get_by_id(self, oq_id: str):
+        return self._questions.get(oq_id)
+
+    def save(self, oq: OpenQuestion):
+        self._questions[oq.id] = oq
+
+    def delete_by_id(self, oq_id: str) -> None:
+        self.deleted_ids.append(oq_id)
+        self._questions.pop(oq_id, None)
+
+    def create_from_artifact(self, artifact):
+        raise NotImplementedError("Not needed for this test")
+
+
+class FakePURepo:
+    def __init__(self, updates):
+        self._updates = list(updates)
+        self.deleted_source_ids = []
+
+    def list_all(self):
+        return list(self._updates)
+
+    def get_by_id(self, pu_id: str):
+        for pu in self._updates:
+            if pu.id == pu_id:
+                return pu
+        return None
+
+    def save(self, pu: ProposedUpdate):
+        self._updates.append(pu)
+
+    def create_from_artifact(self, artifact):
+        raise NotImplementedError("Not needed for this test")
+
+    def delete_by_source_oq_id(self, oq_id: str):
+        self.deleted_source_ids.append(oq_id)
+        self._updates = [pu for pu in self._updates if pu.source_oq_id != oq_id]
+
+
+class DeleteOQUseCaseTests(unittest.TestCase):
+    # Verifies that deleting an OQ removes it, deletes related PUs, and marks artifact IRRELEVANT.
+    def test_delete_oq_marks_artifact_and_deletes_pus(self):
+        artifact = Artifact(
+            id="art_1",
+            conversation_id="c1",
+            type=ArtifactType.OQ,
+            status="PENDING",
+            rephrasing="",
+            rationale="",
+            summary_of_context="",
+        )
+        oq = OpenQuestion(
+            id="oq_1",
+            artifact_id="art_1",
+            question="Q",
+            context="ctx",
+            status="OPEN",
+            slack_ts=None,
+            decision=None,
+            decision_rationale=None,
+        )
+        pu = ProposedUpdate(
+            id="pu_1",
+            artifact_id="art_1",
+            source_oq_id="oq_1",
+            rephrasing="R",
+            context="ctx",
+            decision="",
+            rationale="",
+            status="DRAFT",
+        )
+
+        oq_repo = FakeOQRepo([oq])
+        artifact_repo = FakeArtifactRepo([artifact])
+        pu_repo = FakePURepo([pu])
+
+        use_case = DeleteOQUseCase(oq_repo, artifact_repo, pu_repo)
+        result = use_case.execute("oq_1")
+
+        self.assertTrue(result.deleted)
+        self.assertEqual(result.artifact_id, "art_1")
+        self.assertEqual(artifact_repo.get_by_id("art_1").status, "IRRELEVANT")
+        self.assertIn("oq_1", oq_repo.deleted_ids)
+        self.assertIn("oq_1", pu_repo.deleted_source_ids)
+
+    def test_returns_false_when_oq_missing(self):
+        oq_repo = FakeOQRepo([])
+        artifact_repo = FakeArtifactRepo([])
+        pu_repo = FakePURepo([])
+
+        use_case = DeleteOQUseCase(oq_repo, artifact_repo, pu_repo)
+        result = use_case.execute("missing")
+
+        self.assertFalse(result.deleted)
+        self.assertIsNone(result.artifact_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ingest_threads.py
+++ b/tests/test_ingest_threads.py
@@ -70,11 +70,15 @@ class IngestThreadsUseCaseTests(unittest.TestCase):
 
         result = use_case.execute(threads)
 
-        self.assertEqual(result.artifacts_created, 1)
-        self.assertEqual(len(repo.saved), 1)
+        self.assertEqual(result.artifacts_created, 2)
+        self.assertEqual(len(repo.saved), 2)
         self.assertEqual(len(result.conversations), 3)
         # only two threads classified (third is duplicate)
         self.assertEqual(len(llm.calls), 2)
+        self.assertTrue(any(art.status == "IRRELEVANT" for art in repo.saved))
+        self.assertEqual(result.oq_count, 1)
+        self.assertEqual(result.pu_count, 0)
+        self.assertEqual(result.irrelevant_count, 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_ingest_use_case.py
+++ b/tests/test_ingest_use_case.py
@@ -90,6 +90,9 @@ class IngestUseCaseTests(unittest.TestCase):
 
         self.assertEqual(result.threads_fetched, 2)
         self.assertEqual(result.artifacts_created, 2)
+        self.assertEqual(result.oq_count, 2)
+        self.assertEqual(result.pu_count, 0)
+        self.assertEqual(result.irrelevant_count, 0)
         self.assertEqual(started["count"], 1)
         self.assertEqual(trace.threads, threads)
         self.assertEqual(len(trace.conversations), 2)
@@ -111,6 +114,9 @@ class IngestUseCaseTests(unittest.TestCase):
 
         self.assertEqual(result.threads_fetched, 0)
         self.assertEqual(result.artifacts_created, 0)
+        self.assertEqual(result.oq_count, 0)
+        self.assertEqual(result.pu_count, 0)
+        self.assertEqual(result.irrelevant_count, 0)
         self.assertEqual(started["count"], 0)
         self.assertEqual(slack.calls, ["C_EMPTY"])
         self.assertEqual(len(llm.calls), 0)

--- a/tests/test_list_use_cases.py
+++ b/tests/test_list_use_cases.py
@@ -31,7 +31,7 @@ class FakePURepo:
 
 
 class ListUseCasesTests(unittest.TestCase):
-    # Verifies that list use cases return repository data unchanged.
+    # Verifies that list use cases return the expected items.
     def test_list_artifacts(self):
         artifacts = [
             Artifact(
@@ -59,11 +59,21 @@ class ListUseCasesTests(unittest.TestCase):
                 slack_ts=None,
                 decision=None,
                 decision_rationale=None,
-            )
+            ),
+            OpenQuestion(
+                id="oq_2",
+                artifact_id="art_2",
+                question="Q2",
+                context="ctx",
+                status="TRANSFORMED",
+                slack_ts=None,
+                decision=None,
+                decision_rationale=None,
+            ),
         ]
         use_case = ListOpenQuestionsUseCase(FakeOQRepo(questions))
         result = use_case.execute()
-        self.assertEqual(result, questions)
+        self.assertEqual(result, [questions[0]])
 
     def test_list_proposed_updates(self):
         updates = [

--- a/tests/test_modify_oq.py
+++ b/tests/test_modify_oq.py
@@ -52,7 +52,7 @@ class FakePURepo:
 
 # Verifies that ModifyOQUseCase updates fields and normalizes status.
 class ModifyOQUseCaseTests(unittest.TestCase):
-    def test_updates_fields_and_sets_open(self):
+    def test_updates_fields_and_sets_decided_when_complete(self):
         oq = OpenQuestion(
             id="oq_1",
             artifact_id="art_1",
@@ -82,7 +82,7 @@ class ModifyOQUseCaseTests(unittest.TestCase):
         self.assertEqual(result.oq.context, "New context")
         self.assertEqual(result.oq.decision, "DECISION")
         self.assertEqual(result.oq.decision_rationale, "WHY")
-        self.assertEqual(result.oq.status, "OPEN")
+        self.assertEqual(result.oq.status, "DECIDED")
         self.assertIsNotNone(result.oq.last_modified_at)
 
     def test_sets_open_when_decision_incomplete(self):

--- a/tests/test_modify_oq.py
+++ b/tests/test_modify_oq.py
@@ -52,7 +52,7 @@ class FakePURepo:
 
 # Verifies that ModifyOQUseCase updates fields and normalizes status.
 class ModifyOQUseCaseTests(unittest.TestCase):
-    def test_updates_fields_and_sets_decided_when_complete(self):
+    def test_updates_fields_and_sets_open(self):
         oq = OpenQuestion(
             id="oq_1",
             artifact_id="art_1",
@@ -82,7 +82,8 @@ class ModifyOQUseCaseTests(unittest.TestCase):
         self.assertEqual(result.oq.context, "New context")
         self.assertEqual(result.oq.decision, "DECISION")
         self.assertEqual(result.oq.decision_rationale, "WHY")
-        self.assertEqual(result.oq.status, "DECIDED")
+        self.assertEqual(result.oq.status, "OPEN")
+        self.assertIsNotNone(result.oq.last_modified_at)
 
     def test_sets_open_when_decision_incomplete(self):
         oq = OpenQuestion(
@@ -120,7 +121,7 @@ class ModifyOQUseCaseTests(unittest.TestCase):
         self.assertFalse(result.updated)
         self.assertIsNone(result.oq)
 
-    def test_decided_oq_deletes_old_pu_and_recreates_new_one(self):
+    def test_decided_oq_deletes_old_pu_without_recreating(self):
         oq = OpenQuestion(
             id="oq_3",
             artifact_id="art_3",
@@ -150,38 +151,7 @@ class ModifyOQUseCaseTests(unittest.TestCase):
 
         self.assertTrue(result.updated)
         self.assertIn("oq_3", pu_repo.deleted_source_ids)
-        self.assertEqual(len(pu_repo.saved), 1)
-        new_pu = pu_repo.saved[0]
-        self.assertEqual(new_pu.source_oq_id, "oq_3")
-        self.assertEqual(new_pu.context, "new ctx")
-
-    def test_open_oq_becomes_decided_and_creates_pu(self):
-        oq = OpenQuestion(
-            id="oq_4",
-            artifact_id="art_4",
-            question="Q4",
-            context="ctx",
-            status="OPEN",
-            slack_ts=None,
-            decision=None,
-            decision_rationale=None,
-        )
-
-        oq_repo = FakeOQRepo([oq])
-        pu_repo = FakePURepo()
-        use_case = ModifyOQUseCase(oq_repo, pu_repo)
-
-        result = use_case.execute(
-            "oq_4",
-            decision="DECISION",
-            decision_rationale="WHY",
-        )
-
-        self.assertTrue(result.updated)
-        self.assertEqual(result.oq.status, "DECIDED")
-        self.assertEqual(len(pu_repo.saved), 1)
-        new_pu = pu_repo.saved[0]
-        self.assertEqual(new_pu.source_oq_id, "oq_4")
+        self.assertEqual(len(pu_repo.saved), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_publish_oq.py
+++ b/tests/test_publish_oq.py
@@ -38,7 +38,7 @@ class FakeSlackPublish:
 
 
 class PublishOQsUseCaseTests(unittest.TestCase):
-    # Verifies publish/republish/skip behavior based on last_modified_at.
+    # Verifies publish/republish/skip behavior based on status and last_modified_at.
     def test_publish_new_and_skip_unmodified(self):
         oq_new = OpenQuestion(
             id="oq_1",
@@ -95,6 +95,27 @@ class PublishOQsUseCaseTests(unittest.TestCase):
         self.assertIn("oq_3", result.updated_ids)
         self.assertEqual(len(slack.updates), 1)
         self.assertEqual(slack.updates[0][1], "333.444")
+
+    # Ensures non-OPEN OQs are skipped.
+    def test_skip_when_status_not_open(self):
+        oq_transformed = OpenQuestion(
+            id="oq_4",
+            artifact_id="art_4",
+            question="Q4",
+            context="ctx",
+            status="TRANSFORMED",
+            slack_ts=None,
+        )
+
+        repo = FakeOQRepo([oq_transformed])
+        slack = FakeSlackPublish()
+        use_case = PublishOQsUseCase(repo, slack)
+
+        result = use_case.execute(["oq_4"], "C1")
+
+        self.assertIn("oq_4", result.skipped_ids)
+        self.assertEqual(len(slack.posts), 0)
+        self.assertEqual(len(slack.updates), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_publish_oq.py
+++ b/tests/test_publish_oq.py
@@ -1,0 +1,101 @@
+import unittest
+
+from src.domain.models import OpenQuestion
+from src.use_cases.publish_oq import PublishOQsUseCase
+
+
+class FakeOQRepo:
+    def __init__(self, questions):
+        self._questions = {q.id: q for q in questions}
+        self.saved = []
+
+    def list_all(self):
+        return list(self._questions.values())
+
+    def get_by_id(self, oq_id: str):
+        return self._questions.get(oq_id)
+
+    def save(self, oq: OpenQuestion):
+        self._questions[oq.id] = oq
+        self.saved.append(oq)
+
+    def create_from_artifact(self, artifact):
+        raise NotImplementedError("Not needed for this test")
+
+
+class FakeSlackPublish:
+    def __init__(self):
+        self.posts = []
+        self.updates = []
+
+    def post_message(self, channel_id: str, text: str) -> str:
+        self.posts.append((channel_id, text))
+        return "123.456"
+
+    def update_message(self, channel_id: str, message_ts: str, text: str) -> str:
+        self.updates.append((channel_id, message_ts, text))
+        return message_ts
+
+
+class PublishOQsUseCaseTests(unittest.TestCase):
+    # Verifies publish/republish/skip behavior based on last_modified_at.
+    def test_publish_new_and_skip_unmodified(self):
+        oq_new = OpenQuestion(
+            id="oq_1",
+            artifact_id="art_1",
+            question="Q1",
+            context="ctx",
+            status="OPEN",
+            slack_ts=None,
+        )
+        oq_published = OpenQuestion(
+            id="oq_2",
+            artifact_id="art_2",
+            question="Q2",
+            context="ctx",
+            status="PUBLISHED",
+            slack_ts=None,
+            published_at="2025-01-01T00:00:00",
+            published_message_ts="111.222",
+            published_channel_id="C1",
+            last_modified_at="2025-01-01T00:00:00",
+        )
+
+        repo = FakeOQRepo([oq_new, oq_published])
+        slack = FakeSlackPublish()
+        use_case = PublishOQsUseCase(repo, slack)
+
+        result = use_case.execute(["oq_1", "oq_2"], "C1")
+
+        self.assertIn("oq_1", result.published_ids)
+        self.assertIn("oq_2", result.skipped_ids)
+        self.assertEqual(len(slack.posts), 1)
+        self.assertEqual(len(slack.updates), 0)
+
+    def test_republish_when_modified(self):
+        oq_modified = OpenQuestion(
+            id="oq_3",
+            artifact_id="art_3",
+            question="Q3",
+            context="ctx",
+            status="OPEN",
+            slack_ts=None,
+            published_at="2025-01-01T00:00:00",
+            published_message_ts="333.444",
+            published_channel_id="C1",
+            last_modified_at="2025-01-02T00:00:00",
+        )
+
+        repo = FakeOQRepo([oq_modified])
+        slack = FakeSlackPublish()
+        use_case = PublishOQsUseCase(repo, slack)
+
+        result = use_case.execute(["oq_3"], "C1")
+
+        self.assertIn("oq_3", result.updated_ids)
+        self.assertEqual(len(slack.updates), 1)
+        self.assertEqual(slack.updates[0][1], "333.444")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reset_data.py
+++ b/tests/test_reset_data.py
@@ -1,0 +1,27 @@
+import unittest
+
+from src.use_cases.reset_data import ResetDataUseCase
+
+
+class FakeDataResetPort:
+    def __init__(self):
+        self.called = False
+
+    def reset_all(self) -> None:
+        self.called = True
+
+
+class ResetDataUseCaseTests(unittest.TestCase):
+    # Verifies that ResetDataUseCase calls the reset port.
+    def test_resets_data(self):
+        port = FakeDataResetPort()
+        use_case = ResetDataUseCase(port)
+
+        result = use_case.execute()
+
+        self.assertTrue(result.success)
+        self.assertTrue(port.called)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_set_last_ts.py
+++ b/tests/test_set_last_ts.py
@@ -1,0 +1,28 @@
+import unittest
+
+from src.use_cases.set_last_ts import SetLastTsUseCase
+
+
+class FakeSourcesState:
+    def __init__(self):
+        self.last_call = None
+
+    def set_last_ts(self, channel_id: str, last_ts: str) -> None:
+        self.last_call = (channel_id, last_ts)
+
+
+class SetLastTsUseCaseTests(unittest.TestCase):
+    # Verifies that SetLastTsUseCase computes and stores last_ts.
+    def test_sets_last_ts_from_days(self):
+        fake_state = FakeSourcesState()
+        use_case = SetLastTsUseCase(fake_state)
+
+        result = use_case.execute("C1", 3, now_ts=1_000_000.0)
+
+        expected = 1_000_000.0 - (3 * 86400)
+        self.assertEqual(result.last_ts, f"{expected:.6f}")
+        self.assertEqual(fake_state.last_call, ("C1", f"{expected:.6f}"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_transform_oq.py
+++ b/tests/test_transform_oq.py
@@ -77,6 +77,29 @@ class TransformOQUseCaseTests(unittest.TestCase):
         self.assertEqual(created_pu.context, "ctx")
         self.assertEqual(created_pu.rationale, "WHY")
 
+    def test_transforms_ready_to_transform_oqs(self):
+        oq_ready = OpenQuestion(
+            id="oq_ready",
+            artifact_id="art_ready",
+            question="Q ready",
+            context="ctx",
+            status="READY_TO_TRANSFORM",
+            slack_ts=None,
+            decision="DECISION",
+            decision_rationale="WHY",
+        )
+
+        oq_repo = FakeOQRepo([oq_ready])
+        pu_repo = FakePURepo()
+        use_case = TransformOQUseCase(oq_repo, pu_repo)
+
+        result = use_case.execute()
+
+        self.assertEqual(result.transformed_count, 1)
+        self.assertEqual(result.open_questions_remaining, 0)
+        self.assertEqual(len(pu_repo.saved), 1)
+        self.assertEqual(oq_repo.get_by_id("oq_ready").status, "TRANSFORMED")
+
     def test_no_decided_oqs_creates_nothing(self):
         oq_undecided = OpenQuestion(
             id="oq_3",

--- a/tests/test_wiring_smoke.py
+++ b/tests/test_wiring_smoke.py
@@ -22,6 +22,7 @@ class WiringSmokeTests(unittest.TestCase):
         self.assertIsNotNone(wiring.build_set_last_ts_use_case())
         self.assertIsNotNone(wiring.build_delete_oq_use_case())
         self.assertIsNotNone(wiring.build_delete_oq_batch_use_case())
+        self.assertIsNotNone(wiring.build_publish_oqs_use_case())
 
 
 if __name__ == "__main__":

--- a/tests/test_wiring_smoke.py
+++ b/tests/test_wiring_smoke.py
@@ -18,6 +18,7 @@ class WiringSmokeTests(unittest.TestCase):
         self.assertIsNotNone(wiring.build_list_open_questions_use_case())
         self.assertIsNotNone(wiring.build_list_proposed_updates_use_case())
         self.assertIsNotNone(wiring.build_init_sync_use_case())
+        self.assertIsNotNone(wiring.build_reset_data_use_case())
 
 
 if __name__ == "__main__":

--- a/tests/test_wiring_smoke.py
+++ b/tests/test_wiring_smoke.py
@@ -11,6 +11,7 @@ class WiringSmokeTests(unittest.TestCase):
         self.assertIsNotNone(wiring.build_transform_oq_use_case())
         self.assertIsNotNone(wiring.build_approve_pu_use_case())
         self.assertIsNotNone(wiring.build_add_decision_use_case())
+        self.assertIsNotNone(wiring.build_decision_from_thread_use_case())
         self.assertIsNotNone(wiring.build_modify_oq_use_case())
         self.assertIsNotNone(wiring.build_change_artifact_status_use_case())
         self.assertIsNotNone(wiring.build_change_artifact_status_batch_use_case())

--- a/tests/test_wiring_smoke.py
+++ b/tests/test_wiring_smoke.py
@@ -19,6 +19,8 @@ class WiringSmokeTests(unittest.TestCase):
         self.assertIsNotNone(wiring.build_list_proposed_updates_use_case())
         self.assertIsNotNone(wiring.build_init_sync_use_case())
         self.assertIsNotNone(wiring.build_reset_data_use_case())
+        self.assertIsNotNone(wiring.build_set_last_ts_use_case())
+        self.assertIsNotNone(wiring.build_delete_oq_use_case())
 
 
 if __name__ == "__main__":

--- a/tests/test_wiring_smoke.py
+++ b/tests/test_wiring_smoke.py
@@ -21,6 +21,7 @@ class WiringSmokeTests(unittest.TestCase):
         self.assertIsNotNone(wiring.build_reset_data_use_case())
         self.assertIsNotNone(wiring.build_set_last_ts_use_case())
         self.assertIsNotNone(wiring.build_delete_oq_use_case())
+        self.assertIsNotNone(wiring.build_delete_oq_batch_use_case())
 
 
 if __name__ == "__main__":

--- a/ui.py
+++ b/ui.py
@@ -1,0 +1,5 @@
+from src.ui.app import main
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Technical and Functional Spec - Epic "Build decision from published OQ thread"

## 1) Goal
Automatically build a `decision` and a `decision_rationale` for a previously published Open Question (OQ) in Slack, based on technical team thread replies, via LLM.

Key product constraint:
- Do not automatically move a `PUBLISHED` OQ to `DECIDED`.
- Introduce an intermediate status `READY_TO_TRANSFORM` to distinguish:
  - published OQ without generated decision
  - published OQ with generated decision, ready for review/transform.

## 2) Functional scope
In scope:
- Fetch a targeted Slack thread from a published OQ.
- Filter eligible replies (technical team).
- Call LLM to generate `decision` + `decision_rationale`.
- Persist decision fields on the OQ.
- Apply status transition `PUBLISHED -> READY_TO_TRANSFORM`.
- Allow OQ-to-PU transformation for `READY_TO_TRANSFORM`.
- Expose flow in CLI and UI.

Out of scope:
- Formal human validation workflow.
- LLM confidence score.
- Decision version history.
- Advanced multi-thread conflict handling.

## 3) Prerequisites and configuration
Required variables:
- `SLACK_BOT_TOKEN`
- `OPENAI_API_KEY`
- `OPENAI_MODEL` (default: `gpt-4o`)
- `OPENAI_DECISION_MODEL` (optional, overrides decision model)
- `TECH_TEAM_USER_IDS` (optional, comma-separated Slack user IDs)

If `TECH_TEAM_USER_IDS` is empty:
- all non-bot replies are considered eligible.

## 4) End-to-end flow
1. An OQ is published with `publish_oq`.
2. The system stores publication metadata:
   - `published_channel_id`
   - `published_message_ts`
   - `published_at`
   - `status = PUBLISHED`
3. The team replies in the Slack thread.
4. User triggers `oq_decide_thread <oq_id>` (CLI) or "Build decision" (UI).
5. Use case fetches the Slack thread and filters eligible messages.
6. LLM returns strict JSON with:
   - `decision`
   - `decision_rationale`
7. The system persists both fields on the OQ.
8. Status rule applied:
   - if current status is `PUBLISHED` and decision is valid: `READY_TO_TRANSFORM`
   - otherwise keep historical logic (`OPEN/DECIDED`)
9. `oq_transform` can then convert `READY_TO_TRANSFORM` OQs to PUs (`TRANSFORMED`).

## 5) Detailed business rules
Thread message eligibility for decision input:
- Exclude thread root message (`msg.ts == thread_ts`).
- Exclude bot messages (`bot_id` or `subtype=bot_message`).
- Require `user` to be present.
- If `TECH_TEAM_USER_IDS` is defined: `user` must belong to it.
- Require non-empty `text`.

LLM output validation:
- If payload is missing: fail with `llm_failed`.
- If `decision` or `decision_rationale` is empty: fail with `empty_decision`.
- No partial DB write on failure.

Returned failure reasons:
- `missing_oq`
- `not_published`
- `thread_missing`
- `no_tech_messages`
- `llm_failed`
- `empty_decision`

## 6) Architecture
Inbound adapters:
- CLI: `oq_decide_thread`
- Desktop UI: "Build decision" action

Application use case:
- `BuildDecisionFromThreadUseCase`

Ports:
- `SlackThreadsPort.fetch_thread(channel_id, thread_ts)`
- `LLMDecisionPort.decide(question, context, thread_text)`
- `OpenQuestionRepository`

Outbound adapters:
- Slack: `SlackSDKThreadsAdapter` + `slack_reader.fetch_slack_thread()`
- LLM: `OpenAILLMDecision`
- Persistence: `JsonOpenQuestionRepository`

Wiring:
- `build_decision_from_thread_use_case()`
- optional injection of `TECH_TEAM_USER_IDS`

## 7) Data contracts
Decision prompt:
- File: `src/prompts/decision_from_thread.txt`
- Input: `question`, `context`, `thread`
- Required output: JSON with `decision`, `decision_rationale`

Slack thread read model:
- `ts`
- `channel_id`
- `thread_url`
- `messages[]`

Traceability metadata in the broader pipeline:
- `source_channel_id`
- `source_thread_ts`
- `source_thread_url`

Primary persistence:
- `open_questions.json`: OQ status + decision fields + publication metadata
- `artifacts.json`: source thread traceability
- `proposed_updates.json`: source metadata propagation

## 8) UX/interface impact
CLI:
- New command: `oq_decide_thread <oq_id>`
- Explicit mapping from failure reasons to user messages

UI:
- OQ action: "Build decision"
- User confirmation before execution
- Displays number of messages used
- Explicit failure reason mapping

## 9) OQ -> PU transformation rules
`TransformOQUseCase` now accepts source statuses:
- `OPEN`
- `DECIDED`
- `READY_TO_TRANSFORM`

Unchanged condition:
- transformation only when both decision and rationale are non-empty.

Post-condition:
- transformed OQ -> `TRANSFORMED`
- PU created with context + decision + source traceability.

## 10) Unit test strategy
Added/updated tests:
- `test_build_decision_from_thread.py`
  - covers all failure reasons
  - covers message filtering
  - covers decision/rationale persistence
  - covers `PUBLISHED -> READY_TO_TRANSFORM` transition
- `test_transform_oq.py`
  - covers transformation from `READY_TO_TRANSFORM`
- `test_wiring_smoke.py`
  - covers wiring for the new use case

## 11) Acceptance criteria
- A published OQ with eligible replies and valid LLM output becomes `READY_TO_TRANSFORM`.
- A published OQ does not automatically become `DECIDED` through this flow.
- `oq_transform` transforms `READY_TO_TRANSFORM` OQs.
- Errors are deterministic and exposed through `reason`.
- Feature is exposed in both CLI and UI.

## 12) Known limitations / technical debt
- `ListOpenQuestionsUseCase` only returns `OPEN` (it excludes `READY_TO_TRANSFORM`).
- `ModifyOQUseCase` recomputes status as `DECIDED/OPEN` (it can overwrite `READY_TO_TRANSFORM` after manual edits).
- No strict runtime JSON schema validation beyond required non-empty fields.
- No Slack replies pagination in this specific flow.
